### PR TITLE
Use "python setup.py install" instead of git-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - ln -s ../ amrclaw
   
 install:
+  - export PYTHONPATH=${PWD}:$PYTHONPATH
   - python setup.py install
   - export CLAW=${PWD}
   - export FC=gfortran


### PR DESCRIPTION
This PR changes the `python setup.py git-dev` to the usual "python setup.py install".
This is better, so that we test the canonical installation that the user might do.

All tests pass.
