### PR TITLE
Adding zeroing of very small values in gauge output

### DIFF
--- a/src/2d/dumpgauge.f
+++ b/src/2d/dumpgauge.f
@@ -73,7 +73,7 @@ c       # output values at gauge, along with gauge no, level, time:
 
         ! Zero out tiny values to prevent later problems reading data,
         ! as done in valout.f
-        do j = 1,3
+        do j = 1,nvar
            if (abs(var(j)) < 1d-90) var(j) = 0.d0
         end do
 


### PR DESCRIPTION
Port of change in Geoclaw PR 60 to AMRCLAW -- put tiny values to zero in gauge output the same as in valout.
