### PR TITLE
Increase `maxgr` parameter to 15000

### DIFF
--- a/src/2d/amr_module.f90
+++ b/src/2d/amr_module.f90
@@ -50,7 +50,7 @@ module amr_module
     integer, parameter :: iinfinity = 999999999
     integer, parameter :: horizontal = 1
     integer, parameter :: vertical = 2
-    integer, parameter :: maxgr = 5000
+    integer, parameter :: maxgr = 15000
     integer, parameter :: maxlv = 10
     integer, parameter :: maxcl = 500
 


### PR DESCRIPTION
There has been a series of problems that have cropped up where the control on the maximum number of grids in AMR is too low.  The parameter in question is `maxgr` and was previously set to 5000.  This PR increases this to 15000 right now, this value is not set in stone so if someone feels differently about this say something.
