### PR TITLE
Remove `ngrids` parameter from amr_modulde

### DIFF
--- a/src/2d/amr_module.f90
+++ b/src/2d/amr_module.f90
@@ -80,8 +80,6 @@ module amr_module
             numgrids(maxlv),numcells(maxlv), &
             iorder,mxnest,kcheck
 
-    integer ngrids
-
     ! ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
     ! ::::  for alloc array/memory
     ! ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/3d/amr_module.f90
+++ b/src/3d/amr_module.f90
@@ -84,8 +84,6 @@ module amr_module
             numgrids(maxlv),numcells(maxlv), &
             iorder,mxnest,kcheck
 
-    integer ngrids
-
     ! ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
     ! ::::  for alloc array/memory
     ! ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
`ngrids` is not needed in `amr_module`, it is used locally in a number of places though.

@mjberger pointed this out awhile ago and I am not just getting to it (sorry).
