### PR TITLE
Fix test so cqxx incorporated into transverse solve only if second order...

### DIFF
--- a/src/2d/flux2.f
+++ b/src/2d/flux2.f
@@ -163,7 +163,7 @@ c
 c
        if (method(3).eq.0) go to 999   !# no transverse propagation
 c
-       if (method(3).eq.2) then
+       if (method(2).gt.1 .and. method(3).eq.2) then
 c         # incorporate cqxx into amdq and apdq so that it is split also.
           do 150 i = 1, mx+1
              do 150 m=1,meqn


### PR DESCRIPTION
... method is being used -- to agree with code in clawpack/classic/src/2d/flux2.f90

In principle the user should not set 

```
    clawdata.order = 1
    clawdata.transverse_waves = 2
```

since only 0 or 1 make sense for `transverse_waves` in this case, but I just wanted to see do a quick comparison with the 1st order method and forgot to change this.  In the current code it then adds in garbage from cqxx being un-initialized.  This PR fixes this to agree with what's done in the classic code.

The same change needs to be made in geoclaw.

We might also want to modify `clawpack/clawutil/src/python/clawutil/data.py` to put in a warning for this?
