### PR TITLE
Qadbugfix

### DIFF
--- a/src/3d/outmsh.f
+++ b/src/3d/outmsh.f
@@ -38,7 +38,7 @@ c
      1       13h, level ptr =,i4,24x,1h!)
       write(outunit,103) node(store1,mptr),node(store2,mptr),
      1                   node(cfluxptr,mptr),node(ffluxptr,mptr)
- 103  format(1x,'! storage locs =',2i8,'  bndry locs =',2i8,14x,1h!)
+ 103  format(1x,'! storage locs =',2i12,'  bndry locs =',2i8,6x,1h!)
       write(outunit,104)
       write(outunit,111) rnode(cornxhi,mptr),
      2                   rnode(cornyhi,mptr),

--- a/src/3d/saveqc.f
+++ b/src/3d/saveqc.f
@@ -6,7 +6,7 @@ c
       use amr_module
       implicit double precision (a-h,o-z)
 
-      logical sticksout
+      logical sticksout, perdom3
 c
 c ::::::::::::::::::::::::: SAVEQC :::::::::::::::::::::::::::::::::
 c prepare new fine grids to save fluxes after each integration step
@@ -71,7 +71,8 @@ c         make coarsened enlarged patch for conservative fixup
            sticksout = .false.
        endif
 
-       if (sticksout .and. (xperdom .or. yperdom .or. zperdom)) then
+       perdom3 = xperdom .and. yperdom .and. zperdom
+       if (sticksout .and. perdom3) then
          call preicall(alloc(loctmp),alloc(loctx),nrow,ncol,nfil,
      .                    nvar,naux,
      .                 iclo,ichi,jclo,jchi,kclo,kchi,level-1)
@@ -81,8 +82,8 @@ c         make coarsened enlarged patch for conservative fixup
      .                   iclo,ichi,jclo,jchi,kclo,kchi,level-1,1,1,1)
        endif
 
-       ! still need to set remaining aux cells that stick out of domain
-       if (naux .gt. 0 .and. sticksout) then
+!      still need to set remaining aux cells that stick out of domain
+       if (naux .gt. 0 .and. sticksout .and. .not. perdom3) then
           call setaux(ng,nrow,ncol,nfil,xl,yf,zb,
      .                hxc,hyc,hzc,naux,alloc(loctx))
        endif

--- a/src/3d/saveqc.f
+++ b/src/3d/saveqc.f
@@ -19,6 +19,7 @@ c
       hxc  = hxposs(levc)
       hyc  = hyposs(levc)
       hzc  = hzposs(levc)
+      ng   = 0  ! no ghost cells on coarsened enlarged patch
 
       mkid = lstart(level)
  10   if (mkid .eq. 0) go to 99
@@ -70,7 +71,7 @@ c         make coarsened enlarged patch for conservative fixup
            sticksout = .false.
        endif
 
-       if (xperdom .and. yperdom .and. zperdom .and. sticksout) then
+       if (sticksout .and. (xperdom .or. yperdom .or. zperdom)) then
          call preicall(alloc(loctmp),alloc(loctx),nrow,ncol,nfil,
      .                    nvar,naux,
      .                 iclo,ichi,jclo,jchi,kclo,kchi,level-1)
@@ -78,7 +79,13 @@ c         make coarsened enlarged patch for conservative fixup
          call icall(alloc(loctmp),alloc(loctx),nrow,ncol,nfil,
      .                 nvar,naux,
      .                   iclo,ichi,jclo,jchi,kclo,kchi,level-1,1,1,1)
-          endif
+       endif
+
+       ! still need to set remaining aux cells that stick out of domain
+       if (naux .gt. 0 .and. sticksout) then
+          call setaux(ng,nrow,ncol,nfil,xl,yf,zb,
+     .                hxc,hyc,hzc,naux,alloc(loctx))
+       endif
 c
           call bc3amr(alloc(loctmp),alloc(loctx),nrow,ncol,nfil,
      1               nvar,naux,hxc,hyc,hzc,level,time,


### PR DESCRIPTION
missing setting of aux arrays that stick out of domain, as in 2d.  (Not used, but caused errors en route).  Copied fix from 2d.