### PR TITLE
amr3.f90 needs to set num_gauges=0 before first call to advanc 

### DIFF
--- a/src/3d/amr3.f90
+++ b/src/3d/amr3.f90
@@ -499,10 +499,10 @@ program amr3
         ! Hold off on gauges until grids are set. 
         ! The fake call to advance at the very first timestep 
         ! looks at the gauge array but it is not yet built
-        !num_gauge_SAVE = num_gauges
-        !num_gauges = 0
+        num_gauge_SAVE = num_gauges
+        num_gauges = 0
         call setgrd(nvar,cut,naux,dtinit,t0)
-        !num_gauges = num_gauge_SAVE
+        num_gauges = num_gauge_SAVE
 
 ! commented out to match 4-x version
 !!$        if (possk(1) .gt. dtinit*cflv1/cfl .and. vtime) then

--- a/src/3d/amr3.f90
+++ b/src/3d/amr3.f90
@@ -98,7 +98,8 @@ program amr3
     integer :: i, iaux, mw, level
     integer :: ndim, nvar, naux, mcapa1, mindim
     integer :: nstart, nsteps, nv1, nx, ny, nz, lentotsave
-    !integer :: nstart, nsteps, nv1, nx, ny, lentotsave, num_gauge_SAVE
+    !integer :: nstart, nsteps, nv1, nx, ny, lentotsave
+    integer :: num_gauge_SAVE
     integer :: omp_get_max_threads, maxthreads
     real(kind=8) :: time, ratmet, cut, dtinit, dt_max
     logical :: vtime, rest, output_t0    


### PR DESCRIPTION
- forgot to uncomment these lines when gauges added.