### PR TITLE
Created a regions module for 3d... not yet fully implemented though.

### DIFF
--- a/src/3d/amr3.f90
+++ b/src/3d/amr3.f90
@@ -89,7 +89,7 @@ program amr3
 
     use amr_module, only: t0, tstart_thisrun
 
-    !use regions_module, only: set_regions
+    use regions_module, only: set_regions
     use gauges_module, only: set_gauges, num_gauges
 
     implicit none
@@ -377,7 +377,7 @@ program amr3
     ! ==========================================================================
 
     ! Read in region and gauge data
-    !call set_regions('regions.data')
+    call set_regions('regions.data')
     call set_gauges('gauges.data')
 
 

--- a/src/3d/regions_module.f90
+++ b/src/3d/regions_module.f90
@@ -1,0 +1,65 @@
+! ==============================================================================
+!  Regions Module
+!   Module containing data structures and setup routines for region refinement.
+!
+! ==============================================================================
+module regions_module
+
+    implicit none
+    save
+
+    ! Region type definition
+    type region_type
+        integer :: min_level,max_level
+        real(kind=8) :: x_low,y_low,z_low,x_hi,y_hi,z_hi,t_low,t_hi
+    end type region_type
+
+    integer :: num_regions
+    type(region_type), allocatable :: regions(:)
+      
+contains
+
+    subroutine set_regions(fname)
+
+        use amr_module
+      
+        implicit none
+      
+        ! Function Arguments
+        character(len=*), optional, intent(in) :: fname
+      
+        ! Locals
+        integer, parameter :: unit = 7
+        integer :: i
+
+        write(parmunit,*) ' '
+        write(parmunit,*) '--------------------------------------------'
+        write(parmunit,*) 'REGIONS:'
+        write(parmunit,*) '-----------'
+
+        if (present(fname)) then
+            call opendatafile(unit,fname)
+        else
+            call opendatafile(unit,'regions.data')
+        endif
+
+        read(unit,"(i2)") num_regions
+        if (num_regions == 0) then
+            write(parmunit,*) '  No regions specified for refinement'
+            
+        else
+            ! Refinement region data
+            allocate(regions(num_regions))
+            do i=1,num_regions
+                read(unit,*) regions(i)%min_level, regions(i)%max_level, &
+                             regions(i)%t_low, regions(i)%t_hi, &
+                             regions(i)%x_low, regions(i)%x_hi, &
+                             regions(i)%y_low, regions(i)%y_hi, &
+                             regions(i)%z_low, regions(i)%z_hi
+            enddo
+        endif
+        close(unit)
+
+    end subroutine set_regions
+
+end module regions_module

--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -122,7 +122,7 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
 class RegionData(clawpack.clawutil.data.ClawData):
     r""""""
 
-    def __init__(self,regions=None,num_dim=2):
+    def __init__(self,regions=None,num_dim=None):
 
         super(RegionData,self).__init__()
 
@@ -139,10 +139,8 @@ class RegionData(clawpack.clawutil.data.ClawData):
         self.open_data_file(out_file,data_source)
 
         self.data_write(value=len(self.regions),alt_name='num_regions')
-        if (self.num_dim == 3) and (len(self.regions) > 0):
-            raise NotImplementedError("*** Regions not yet implemented in 3d")
         for regions in self.regions:
-            self._out_file.write(8*"%g  " % tuple(regions) +"\n")
+            self._out_file.write(len(regions)*"%g  " % tuple(regions) +"\n")
         self.close_data_file()
 
 
@@ -173,10 +171,7 @@ class RegionData(clawpack.clawutil.data.ClawData):
         self.regions = []
         for n in xrange(num_regions):
             line = data_file.readline().split()
-            self.regions.append([int(line[0]), int(line[1]),
-                                 float(line[2]), float(line[3]), 
-                                 float(line[4]), float(line[5]),
-                                 float(line[6]), float(line[7])])
+            self.regions.append([int(line[0]), int(line[1])] + [float(a) for a in line[2:]])
 
         data_file.close()
 


### PR DESCRIPTION
Not sure if this should be merged as it is, but wanted to start a discussion about it.  These commits will allow a user to specify regions in setrun.py; however, there will be no refinement unless the user manually accounts for regions in flag2refine (which I'm currently using for the seismic project).  I would make the appropriate changes to use the regions in bufnst.f90... but I'm not familiar enough with that file yet.