### PR TITLE
Init advance fix

### DIFF
--- a/src/2d/setgrd.f
+++ b/src/2d/setgrd.f
@@ -33,23 +33,29 @@ c
           lbase  = levold
           lfnew  = lbase
 c
-c  set up level to be flagged. need a solution t=0,and t=dt.
-c  error estimation makes next one at t=2*dt for Richardson.
+c  set up level to be flagged. need a solution t=0,and if
+c  using richardson  error estimation then one at dt too.
+c  then richardson makes one at 2*dt.  for just flag2refine 
+c  only need to set boundary conditions, done from grdfit->flagger.
 c
-         call advanc(levold,nvar,dtlev,vtime,naux)
-         evol = evol + rvol
-         rvol = 0.d0
-         kfac = 1
-         do i = 1, levold-1
-           kfac = kfac * kratio(i)
-         end do
-         dtinit = min(dtinit, dtlev*kfac)
- 
-c        dont count it in real integration stats
-         do 20 level=1,mxnest
- 20         rvoll(level) = 0.d0
+          if (flag_richardson) then
+             call advanc(levold,nvar,dtlev,vtime,naux)
+             evol = evol + rvol !time stepping stats for error estimation
+             rvol = 0.d0        ! reset since not 'real' time stepping stats
+             kfac = 1
+             do i = 1, levold-1
+                kfac = kfac * kratio(i)
+             end do
+             dtinit = min(dtinit, dtlev*kfac)
+             
+c            dont count it in real integration stats
+             do 20 level=1,mxnest
+ 20             rvoll(level) = 0.d0
+             endif
 c
-c  flag, cluster, and make new grids
+c  flag, cluster, and make new grids. grdfit set bcs, controls flagging,
+c  colating and making grids. But advanc called above since if using
+c  richardson, it assumes two levels of solution already exist
 c
          call grdfit(lbase,levold,nvar,naux,cut,time,start_time)
          if (newstl(levnew) .ne. 0) lfnew = levnew
@@ -58,10 +64,10 @@ c  init new level. after each iteration. fix the data structure
 c  also reinitalize coarser grids so fine grids can be advanced
 c  and interpolate correctly for their bndry vals from coarser grids.
 c
-         call ginit(newstl(levnew),.true., nvar, naux, start_time)
+         call ginit(newstl(levnew),.true., nvar, naux,start_time)
          lstart(levnew) = newstl(levnew)
          lfine = lfnew
-         call ginit(lstart(levold),.false., nvar, naux, start_time)
+         call ginit(lstart(levold),.false., nvar, naux,start_time)
 c
 c count number of grids on newly created levels (needed for openmp
 c parallelization). this is also  done in regridding.
@@ -94,7 +100,7 @@ c
 c  switch location of old and new storage for soln. vals, 
 c  and reset time to 0.0 (or initial time start_time)
 c
-      if (mxnest .eq. 1) go to 99
+c      if (mxnest .eq. 1) go to 99  shouldnt be nec. tested above.
 c
       lev = 1
  40   if ((lev .eq. mxnest) .or. (lev .gt. lfine))  go to 60

--- a/src/3d/setgrd.f
+++ b/src/3d/setgrd.f
@@ -33,23 +33,29 @@ c
           lbase  = levold
           lfnew  = lbase
 c
-c  set up level to be flagged. need a solution t=0,and t=dt.
-c  error estimation makes next one at t=2*dt for Richardson.
+c  set up level to be flagged. need a solution t=0,and if
+c  using richardson  error estimation then one at dt too.
+c  then richardson makes one at 2*dt.  for just flag2refine 
+c  only need to set boundary conditions, done from grdfit->flagger.
 c
-         call advanc(levold,nvar,dtlev,vtime,naux)
-         evol = evol + rvol
-         rvol = 0.d0
-         kfac = 1
-         do i = 1, levold-1
-           kfac = kfac * kratio(i)
-         end do
-         dtinit = min(dtinit, dtlev*kfac)
- 
-c        dont count it in real integration stats
-         do 20 level=1,mxnest
- 20         rvoll(level) = 0.d0
+          if (flag_richardson) then
+             call advanc(levold,nvar,dtlev,vtime,naux)
+             evol = evol + rvol !time stepping stats for error estimation
+             rvol = 0.d0        ! reset since not 'real' time stepping stats
+             kfac = 1
+             do i = 1, levold-1
+                kfac = kfac * kratio(i)
+             end do
+             dtinit = min(dtinit, dtlev*kfac)
+             
+c            dont count it in real integration stats
+             do 20 level=1,mxnest
+ 20             rvoll(level) = 0.d0
+             endif
 c
-c  flag, cluster, and make new grids
+c  flag, cluster, and make new grids. grdfit set bcs, controls flagging,
+c  colating and making grids. But advanc called above since if using
+c  richardson, it assumes two levels of solution already exist
 c
          call grdfit(lbase,levold,nvar,naux,cut,time,start_time)
          if (newstl(levnew) .ne. 0) lfnew = levnew
@@ -87,14 +93,14 @@ c
      &               " cells at level ", i3)
           endif 
 c
-         levnew = levnew + 1
+      levnew = levnew + 1
       go to 10
  30   continue
 c
 c  switch location of old and new storage for soln. vals, 
 c  and reset time to 0.0 (or initial time start_time)
 c
-      if (mxnest .eq. 1) go to 99
+c      if (mxnest .eq. 1) go to 99  shouldnt be nec. tested above.
 c
       lev = 1
  40   if ((lev .eq. mxnest) .or. (lev .gt. lfine))  go to 60

--- a/src/3d/stepgrid_dimSplit.f
+++ b/src/3d/stepgrid_dimSplit.f
@@ -44,6 +44,7 @@ c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
       logical    debug,  dump
       data       debug/.false./,  dump/.false./
+
 c
 c
 !--        if (dump .and. mptr .ne. 1) 
@@ -229,8 +230,8 @@ c For variable time stepping, use max speed seen on this grid to
 c choose the allowable new time step dtnew.  This will later be
 c compared to values seen on other grids.
 c
-        if (cflgrid .gt. 0.d0) then
-            dtnew = dt*cfl/cflgrid
+        if (cfl_level .gt. 0.d0) then
+            dtnew = dt*cfl/cfl_level
           else
 c            # velocities are all zero on this grid so there's no
 c            # time step restriction coming from this grid.
@@ -238,9 +239,9 @@ c            # time step restriction coming from this grid.
           endif
 c
 
-      if (cflgrid .gt. cflv1) then
-            write(*,810) cflgrid
-            write(outunit,810) cflgrid
+      if (cfl_level .gt. cflv1) then
+            write(*,810) cfl_level
+            write(outunit,810) cfl_level
   810       format('*** WARNING *** Courant number  =', d12.4,
      &              '  is larger than cflv(1) ')
             endif


### PR DESCRIPTION
this addresses the  issue (in 2d and 3d) with setgrd that it always called advanc even if flag_richardson was false.  Also using this branch to fix incorrect cfl test in 3d dimensional splitting stepgrid.