### PR TITLE
waves and s declared with wrong dimensions in qad

### DIFF
--- a/src/2d/qad.f
+++ b/src/2d/qad.f
@@ -40,7 +40,7 @@ c      #  ok as long as meqn, mwaves < maxvar
 
        parameter (max1dp1 = max1d+1)
        dimension ql(nvar,max1dp1),    qr(nvar,max1dp1)
-       dimension wave(nvar,maxvar,max1dp1), s(nvar,max1dp1)
+       dimension wave(nvar,mwaves,max1dp1), s(mwaves,max1dp1)
        dimension amdq(nvar,max1dp1),  apdq(nvar,max1dp1)
        dimension auxl(maxaux*max1dp1),  auxr(maxaux*max1dp1)
 c

--- a/src/3d/qad.f
+++ b/src/3d/qad.f
@@ -42,7 +42,7 @@ c      #  ok as long as meqn, mwaves < maxvar
        parameter (max1dp1 = max1d+1)
 c      parameter (max1dp1 = (max1d+1)**2+1)
        dimension ql(nvar,max1dp1),    qr(nvar,max1dp1)
-       dimension wave(nvar,maxvar,max1dp1),  s(nvar,max1dp1)
+       dimension wave(nvar,mwaves,max1dp1), s(mwaves,max1dp1)
        dimension amdq(nvar,max1dp1),  apdq(nvar,max1dp1)
        dimension auxl(maux,max1dp1),  auxr(maux,max1dp1)
 


### PR DESCRIPTION
 - not used in qad but passed in to rpn2 and could cause problems there