### PR TITLE
Needed to modify format statement to avoid write error in 3d

### DIFF
--- a/src/3d/gauges_module.f90
+++ b/src/3d/gauges_module.f90
@@ -403,13 +403,14 @@ contains
       ! or checkpoint time, so write whatever is in array and reset.
       ! nextLoc has already been increment before this subr. called
       do j = 1, nextLoc(gaugeNum)-1
-        write(myunit,100) levelArray(j,gaugeNum),      &
-                          (gaugeArray(k,j,gaugeNum),k=1,nvar+1)  ! includes time
+        write(myunit,100,advance='no') levelArray(j,gaugeNum)
+        write(myunit,110) gaugeArray(:,j,gaugeNum)  ! includes time
       end do
       nextLoc(gaugeNum) = 1                        
 
       ! if you want to modify number of digits printed, modify this...
-100     format(i5,5e15.7)
+100     format(i5)
+110     format(5e15.7)
 
       ! close file
       close(myunit)


### PR DESCRIPTION
The last format statement in gauges_module.f90 was causing problems with 3D gauge output.  For whatever reason, the integer specifier would be applied to real values, causing a runtime error and no output.