### PR TITLE
make plotdata an optional argument in setplot

### DIFF
--- a/examples/acoustics_2d_radial/1drad/setplot.py
+++ b/examples/acoustics_2d_radial/1drad/setplot.py
@@ -74,6 +74,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/acoustics_2d_radial/1drad/setplot.py
+++ b/examples/acoustics_2d_radial/1drad/setplot.py
@@ -8,7 +8,7 @@ function setplot is called to set the plot parameters.
 """ 
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -17,6 +17,11 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
 

--- a/examples/acoustics_2d_radial/setplot.py
+++ b/examples/acoustics_2d_radial/setplot.py
@@ -18,7 +18,7 @@ else:
 
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -30,6 +30,11 @@ def setplot(plotdata):
 
 
     from clawpack.visclaw import colormaps
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
     

--- a/examples/acoustics_2d_radial/setplot.py
+++ b/examples/acoustics_2d_radial/setplot.py
@@ -137,6 +137,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/acoustics_3d_interface/setplot.py
+++ b/examples/acoustics_3d_interface/setplot.py
@@ -10,10 +10,10 @@ function setplot is called to set the plot parameters.
     
 """ 
 
+from __future__ import print_function
 
 #--------------------------
-from __future__ import print_function
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -22,6 +22,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     plotdata.clearfigures()  # clear any old figures,axes,items data

--- a/examples/acoustics_3d_interface/setplot.py
+++ b/examples/acoustics_3d_interface/setplot.py
@@ -47,6 +47,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/advection_2d_annulus/setplot.py
+++ b/examples/advection_2d_annulus/setplot.py
@@ -12,7 +12,7 @@ from mapc2p import mapc2p
 import numpy as np
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -21,6 +21,11 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     from clawpack.visclaw import colormaps

--- a/examples/advection_2d_annulus/setplot.py
+++ b/examples/advection_2d_annulus/setplot.py
@@ -129,6 +129,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/advection_2d_inflow/setplot.py
+++ b/examples/advection_2d_inflow/setplot.py
@@ -6,9 +6,10 @@ This module is imported by the plotting routines and then the
 function setplot is called to set the plot parameters.
 """
 
-#--------------------------
 from __future__ import absolute_import
-def setplot(plotdata):
+
+#--------------------------
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -17,6 +18,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     from clawpack.visclaw import colormaps

--- a/examples/advection_2d_inflow/setplot.py
+++ b/examples/advection_2d_inflow/setplot.py
@@ -123,6 +123,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/advection_2d_square/setplot.py
+++ b/examples/advection_2d_square/setplot.py
@@ -6,9 +6,10 @@ This module is imported by the plotting routines and then the
 function setplot is called to set the plot parameters.
 """
 
-#--------------------------
 from __future__ import absolute_import
-def setplot(plotdata):
+
+#--------------------------
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -20,6 +21,11 @@ def setplot(plotdata):
 
 
     from clawpack.visclaw import colormaps
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
 
     plotdata.clearfigures() # clear any old figures,axes,items data
 

--- a/examples/advection_2d_square/setplot.py
+++ b/examples/advection_2d_square/setplot.py
@@ -124,6 +124,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/advection_2d_swirl/setplot.py
+++ b/examples/advection_2d_swirl/setplot.py
@@ -7,10 +7,10 @@ function setplot is called to set the plot parameters.
     
 """ 
 
+from __future__ import absolute_import
 
 #--------------------------
-from __future__ import absolute_import
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -20,8 +20,11 @@ def setplot(plotdata):
     
     """ 
 
-
     from clawpack.visclaw import colormaps
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
     

--- a/examples/advection_2d_swirl/setplot.py
+++ b/examples/advection_2d_swirl/setplot.py
@@ -103,6 +103,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/advection_3d_inflow/setplot.py
+++ b/examples/advection_3d_inflow/setplot.py
@@ -10,10 +10,10 @@ function setplot is called to set the plot parameters.
     
 """ 
 
+from __future__ import print_function
 
 #--------------------------
-from __future__ import print_function
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -22,6 +22,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     plotdata.clearfigures()  # clear any old figures,axes,items data

--- a/examples/advection_3d_inflow/setplot.py
+++ b/examples/advection_3d_inflow/setplot.py
@@ -68,6 +68,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/advection_3d_swirl/setplot.py
+++ b/examples/advection_3d_swirl/setplot.py
@@ -10,10 +10,10 @@ function setplot is called to set the plot parameters.
     
 """ 
 
+from __future__ import print_function
 
 #--------------------------
-from __future__ import print_function
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -22,6 +22,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     plotdata.clearfigures()  # clear any old figures,axes,items data

--- a/examples/advection_3d_swirl/setplot.py
+++ b/examples/advection_3d_swirl/setplot.py
@@ -66,6 +66,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/burgers_2d_square/setplot.py
+++ b/examples/burgers_2d_square/setplot.py
@@ -119,6 +119,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/burgers_2d_square/setplot.py
+++ b/examples/burgers_2d_square/setplot.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import numpy as np
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -23,6 +23,11 @@ def setplot(plotdata):
 
 
     from clawpack.visclaw import colormaps
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
     

--- a/examples/burgers_3d_cubedata/setplot.py
+++ b/examples/burgers_3d_cubedata/setplot.py
@@ -10,10 +10,10 @@ function setplot is called to set the plot parameters.
     
 """ 
 
+from __future__ import print_function
 
 #--------------------------
-from __future__ import print_function
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -22,6 +22,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     plotdata.clearfigures()  # clear any old figures,axes,items data

--- a/examples/burgers_3d_cubedata/setplot.py
+++ b/examples/burgers_3d_cubedata/setplot.py
@@ -47,6 +47,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/euler_2d_quadrants/setplot.py
+++ b/examples/euler_2d_quadrants/setplot.py
@@ -30,8 +30,8 @@ def setplot(plotdata):
 
     # Set up for axes in this figure:
     plotaxes = plotfigure.new_plotaxes()
-    plotaxes.xlimits = 'auto'
-    plotaxes.ylimits = 'auto'
+    plotaxes.xlimits = [0,1]
+    plotaxes.ylimits = [0,1]
     plotaxes.title = 'Density'
     plotaxes.scaled = True
     plotaxes.afteraxes = addgauges
@@ -52,8 +52,8 @@ def setplot(plotdata):
 
     # Set up for axes in this figure:
     plotaxes = plotfigure.new_plotaxes()
-    plotaxes.xlimits = 'auto'
-    plotaxes.ylimits = 'auto'
+    plotaxes.xlimits = [0,1]
+    plotaxes.ylimits = [0,1]
     plotaxes.title = 'Density'
     plotaxes.scaled = True      # so aspect ratio is 1
 
@@ -91,8 +91,8 @@ def setplot(plotdata):
 
     # Set up for axes in this figure:
     plotaxes = plotfigure.new_plotaxes()
-    plotaxes.xlimits = 'auto'
-    plotaxes.ylimits = 'auto'
+    plotaxes.xlimits = [0,1]
+    plotaxes.ylimits = [0,1]
     plotaxes.title = 'Density'
 
     # Plot q as blue curve:

--- a/examples/euler_2d_quadrants/setplot.py
+++ b/examples/euler_2d_quadrants/setplot.py
@@ -120,6 +120,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/examples/euler_2d_quadrants/setplot.py
+++ b/examples/euler_2d_quadrants/setplot.py
@@ -7,9 +7,10 @@ function setplot is called to set the plot parameters.
     
 """ 
 
-#--------------------------
 from __future__ import absolute_import
-def setplot(plotdata):
+
+#--------------------------
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -19,8 +20,12 @@ def setplot(plotdata):
     
     """ 
 
-
     from clawpack.visclaw import colormaps
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
     

--- a/examples/euler_3d_radial/setplot.py
+++ b/examples/euler_3d_radial/setplot.py
@@ -10,11 +10,12 @@ function setplot is called to set the plot parameters.
     
 """ 
 
-
-#--------------------------
 from __future__ import absolute_import
 from __future__ import print_function
-def setplot(plotdata):
+
+
+#--------------------------
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -23,6 +24,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     plotdata.clearfigures()  # clear any old figures,axes,items data

--- a/examples/euler_3d_radial/setplot.py
+++ b/examples/euler_3d_radial/setplot.py
@@ -105,6 +105,7 @@ def setplot(plotdata=None):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 


### PR DESCRIPTION
See clawpack/classic#78.

Also, I added `plotdata.parallel = True` to all the setplot files since this seems to work reliably now and defaults to doing the frames in serial unless the user also sets `plotdata.num_procs` or `OMP_NUM_THREADS`.