### PR TITLE
remove file arg from write of aux_type

### DIFF
--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -87,7 +87,7 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
         self.data_write()  # writes blank line
 
         if self._clawdata.num_aux > 0:
-            self.data_write(file, self.aux_type, 'aux_type')
+            self.data_write('aux_type')
         self.data_write()
 
         self.data_write('flag_richardson')


### PR DESCRIPTION
To work with Python 3.  This is currently causing an error in clawpack/geoclaw#236 and in clawpack/amrclaw#182.