### PR TITLE
Updated dimensions in default src3.f90

### DIFF
--- a/src/3d/src3.f90
+++ b/src/3d/src3.f90
@@ -8,7 +8,7 @@ subroutine src3(meqn,mbc,mx,my,mz,xlower,ylower,zlower,dx,dy,dz,q,maux,aux,t,dt)
     implicit none
     integer, intent(in) :: meqn,mbc,mx,my,mz,maux
     real(kind=8), intent(in) :: xlower,ylower,zlower,dx,dy,dz,t,dt
-    real(kind=8), intent(in) :: aux(maux,1-mbc:mx+mbc,1-mbc:my+mbc)
-    real(kind=8), intent(inout) :: q(meqn,1-mbc:mx+mbc,1-mbc:my+mbc)
+    real(kind=8), intent(in) :: aux(maux,1-mbc:mx+mbc,1-mbc:my+mbc,1-mbc:mz+mbc)
+    real(kind=8), intent(inout) :: q(meqn,1-mbc:mx+mbc,1-mbc:my+mbc,1-mbc:mz+mbc)
 
 end subroutine src3


### PR DESCRIPTION
The q and aux variables still had dimensions from src2.f90.