### PR TITLE
suppress printing the Courant number every time step

### DIFF
--- a/src/2d/stepgrid.f
+++ b/src/2d/stepgrid.f
@@ -118,9 +118,9 @@ c
      &              fm,fp,gm,gp,rpn2,rpt2)
 c
 c
-        write(outunit,1001) mptr, node(nestlevel,mptr),cflgrid
- 1001   format(' Courant # of grid', i4,
-     &        ' on level', i3, ' is  ', e10.3)
+c       write(outunit,1001) mptr, node(nestlevel,mptr),cflgrid
+c1001   format(' Courant # of grid', i4,
+c    &        ' on level', i3, ' is  ', e10.3)
 c
 
 !$OMP  CRITICAL (cflm)


### PR DESCRIPTION
This leads to huge fort.amr files in some cases and presumably nobody ever looks at it in general.

Note that this part is already commented out in geoclaw version of `stepgrid.f`