### PR TITLE
Gauge locations

### DIFF
--- a/src/2d/gauges_module.f90
+++ b/src/2d/gauges_module.f90
@@ -203,7 +203,7 @@ contains
 
                     ! Write header
                     header_1 = "('# gauge_id= ',i5,' " //                   &
-                               "location=( ',1e15.7,' ',1e15.7,' ) " //     &
+                               "location=( ',1e17.10,' ',1e17.10,' ) " //     &
                                "num_var= ',i2)"
                     write(OUTGAUGEUNIT, header_1) gauges(i)%gauge_num,      &
                                                   gauges(i)%x,              &

--- a/src/3d/gauges_module.f90
+++ b/src/3d/gauges_module.f90
@@ -196,11 +196,12 @@ contains
 
                     ! Write header
                     header_1 = "('# gauge_id= ',i5,' " //                   &
-                               "location=( ',1e15.7,' ',1e15.7,' ) " //     &
+                               "location=( ',1e17.10,' ',1e17.10,' ',1e17.10,' ) " //     &
                                "num_var= ',i2)"
                     write(OUTGAUGEUNIT, header_1) gauges(i)%gauge_num,      &
                                                   gauges(i)%x,              &
                                                   gauges(i)%y,              &
+                                                  gauges(i)%z,              &
                                                   gauges(i)%num_out_vars
 
                     ! Construct column labels


### PR DESCRIPTION
Actually I needed this in geoclaw where there's a separate `gauges_module` so I did the same there in clawpack/geoclaw#255.

But I also found a bug in the 3d `gauges_module` -- it was only printing x,y not z.