### PR TITLE
Add checks to make sure alloc array isn't longer than index space allows

### DIFF
--- a/src/2d/colate2.f
+++ b/src/2d/colate2.f
@@ -2,7 +2,7 @@ c
 !> Takes flagged points on all grids on level lcheck
 !! and pack their (i,j) cell centered
 !! indices into the badpts array.
-!! Points in the badpts array are unique and sorted based on 
+!! Points in the badpts array are unique and sorted based on
 !! one dimensional packing of their 2D indices.
 c
 c -----------------------------------------------------------
@@ -14,7 +14,8 @@ c
       dimension badpts(2,len)
       dimension ist(3), iend(3), jst(3), jend(3), ishift(3), jshift(3)
       logical db/.false./
-      integer*8 largestIntEquiv
+      integer*8 largestIntEquiv,ifac1,ifac2
+      integer   largestIntEquiv_default
 
 c
 c    index for flag array now based on integer index space, not 1:mibuff,1:mjbuff
@@ -52,7 +53,7 @@ c
 c        write(outunit,*)" colating flags on grid ",mptr
 
 c        handle each of 4 sides (in 2D)
-c        set tags to negative val. reset to positive if they have a home     
+c        set tags to negative val. reset to positive if they have a home
          ilo = node(ndilo,mptr)
          ihi = node(ndihi,mptr)
          jlo = node(ndjlo,mptr)
@@ -111,7 +112,7 @@ c             neg means no home was found. throw out
                   write(*,*)" still have neg points"
                   go to 60
              endif
-             if (alloc(iadd(i,j)) .eq. goodpt) go to 60  
+             if (alloc(iadd(i,j)) .eq. goodpt) go to 60
 c
 c    got a legit flagged point, bag it.
 c
@@ -160,7 +161,7 @@ c
        if (mptr .ne. 0) go to 10
 
 
-      npts = index 
+      npts = index
       if (gprint) then
         write(outunit,100) npts, lcheck,len
  100    format( i9,' flagged points initially colated on level ',i4,
@@ -171,24 +172,33 @@ c colate flagged points into single integer array for quicksorting
 c
 c     sorting uses one dimensional packing of 2D indices
 c     check if domain will fit  in integer*4.
-c     if not, just leave the duplicate, but rememer that efficiency 
+c     if not, just leave the duplicate, but rememer that efficiency
 c     of grids won't be correct (since divide by number of flaged pts in grid)
 c     If necessary, do whole process in integer*8 - then will have enough
 c     room, but will have to convert quicksort routine and drivesort
 c     the variable largestIntEquiv already declared integer*8 above.
-      largestIntEquiv =  iregsz(lcheck)+mbuff + 
+      ifac1 = iregsz(lcheck)
+      ifac2 = jregsz(lcheck)
+      largestIntEquiv =  ifac1+mbuff +
+     .             (ifac1+2*mbuff)*(ifac2+mbuff)
+      write(*,*) 'level ',lcheck
+      write(*,*) largestIntEquiv
+      largestIntEquiv_default =  iregsz(lcheck)+mbuff +
      .             (iregsz(lcheck)+2*mbuff)*(jregsz(lcheck)+mbuff)
-      largestSingle = 2**30
-      if (largestIntEquiv .le. 0) then
+      write(*,*) largestIntEquiv_default
+c     largestSingle = 2**30
+
+c     ! if get different answer with extra precision then bypass sorting alg.
+      if (largestIntEquiv .ne. largestIntEquiv_default) then
 c       ## sorting alg will have integer overflow
 c       ## just use all flagged points in making grids
-c       ## this means "efficiency" count will be incorrect for 
+c       ## this means "efficiency" count will be incorrect for
 c       ## this and higher levels
           nUniquePts =  npts  ! bad name - they are not unique
       else
           call drivesort(npts,badpts,lcheck,nUniquePts,mbuff)
       endif
-     
+
 
  99   return
       end

--- a/src/2d/colate2.f
+++ b/src/2d/colate2.f
@@ -171,7 +171,7 @@ c
 c colate flagged points into single integer array for quicksorting
 c
 c     sorting uses one dimensional packing of 2D indices
-c     check if domain will fit  in integer*4.
+c     check if domain will fit  in integer*4.  (largestSingle approx 2**30)
 c     if not, just leave the duplicate, but rememer that efficiency
 c     of grids won't be correct (since divide by number of flaged pts in grid)
 c     If necessary, do whole process in integer*8 - then will have enough
@@ -181,12 +181,8 @@ c     the variable largestIntEquiv already declared integer*8 above.
       ifac2 = jregsz(lcheck)
       largestIntEquiv =  ifac1+mbuff +
      .             (ifac1+2*mbuff)*(ifac2+mbuff)
-      write(*,*) 'level ',lcheck
-      write(*,*) largestIntEquiv
       largestIntEquiv_default =  iregsz(lcheck)+mbuff +
      .             (iregsz(lcheck)+2*mbuff)*(jregsz(lcheck)+mbuff)
-      write(*,*) largestIntEquiv_default
-c     largestSingle = 2**30
 
 c     ! if get different answer with extra precision then bypass sorting alg.
       if (largestIntEquiv .ne. largestIntEquiv_default) then

--- a/src/2d/resize_alloc.f90
+++ b/src/2d/resize_alloc.f90
@@ -25,26 +25,16 @@ subroutine resize_storage(new_size,status)
     real(kind=8), allocatable, target, dimension(:) :: new_storage
     
 
-    if (memsize < new_size) then
-        print *, "Expanding storage from ", memsize," to ", new_size
-        allocate(new_storage(new_size),STAT=status)
-        if (status > 0) then
-            return
-        endif
-!       new_storage(1:memsize) = storage   !old way, changed mjb sept. 2014
-        new_storage(1:memsize) = alloc     ! new way, use allocatable, not pointer       
-
-!        call move_alloc(new_storage,storage)
-        call move_alloc(new_storage,alloc)
-
-!        alloc => storage
-        memsize = new_size
-    else
-        print *,'new_size < memsize,'
-        print *,'new_size = ',new_size
-        print *,'memsize = ',memsize
-        stop
+    print *, "Expanding storage from ", memsize," to ", new_size
+    allocate(new_storage(new_size),STAT=status)
+    if (status > 0) then
+        return
     endif
+    new_storage(1:memsize) = alloc     ! new way, use allocatable, not pointer       
+
+    call move_alloc(new_storage,alloc)
+
+    memsize = new_size
     
     return
     


### PR DESCRIPTION

If the default type integer*4 is used then indices of the `alloc` array can only go up to roughly 2**30 \approx 2e9, and the code may die in unexpected ways if the array is longer.

This also fixes a bug that came up in a recent GeoClaw run where it kept doubling the array length of alloc without bound, due to checking for integer overflow by assuming the integer would become negative if it overflows (due to the the leading parity bit).  But if it overflows by too much then it's again positive and the existing checks did not catch this.