### PR TITLE
write floats in regions.data in e format

### DIFF
--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -143,7 +143,10 @@ class RegionData(clawpack.clawutil.data.ClawData):
 
         self.data_write(value=len(self.regions),alt_name='num_regions')
         for regions in self.regions:
-            self._out_file.write(len(regions)*"%g  " % tuple(regions) +"\n")
+            # write minlevel,maxlevel as integers, remaining floats in e format:
+            self._out_file.write("%i  %i " % (regions[0], regions[1]))
+            self._out_file.write((len(regions)-2)*"%20.14e  " % tuple(regions[2:]) +"\n")
+            
         self.close_data_file()
 
 


### PR DESCRIPTION
 to avoid truncating significant figures. 

We ran into a problem where more than 6 digits of longitude are needed to describe a small region and Python's `%g` format wrote out the same values for `x1` and `x2`.  

Here I've used `%20.14e`.  Maybe we should eventually make things consistent between this and other `*.data` files, e.g. in `gauges.data` fewer digits are printed.  Since these data files are normally read only by the Fortran code, might as well use full precision?
