### PR TITLE
Initialize timers consistently in 1d, 2d, 3d

### DIFF
--- a/src/1d/amr_module.f90
+++ b/src/1d/amr_module.f90
@@ -121,7 +121,7 @@ module amr_module
     integer :: timeFlglvl,timeGrdfit2,timeGrdfit3,timeGrdfitAll
     integer :: timeSetaux,timeFilval,timeBound,timeStepgrid,timeFilvalTot
     integer :: timeFlagger, timeBufnst, timeTick, tick_clock_start
-    real(kind=8) tvollCPU(maxlv)
+    real(kind=8) tvollCPU(maxlv), timeTickCPU
     real(kind=8) timeBoundCPU,timeStepgridCPU,timeSetauxCPU,timeRegriddingCPU
     real(kind=8) timeValoutCPU
 

--- a/src/1d/stst1.f
+++ b/src/1d/stst1.f
@@ -63,19 +63,8 @@ c
 c after kcheck integrations of parent grid, move its refinements.
 c finest level grid never needs to have its finer subgrids moved.
 c
-      timeFlagger = 0.
-      timeBufnst = 0.
-      timeStepgrid = 0.
-      timeBound = 0.
-      timeGrdfitAll = 0.
-      timeFlglvl   = 0.
-      timeFlglvlTot   = 0.
-      timeGrdfit2   = 0.
-      timeSetaux    = 0.
-      timeFilval    = 0.
-      timeRegridding = 0.
-      timeUpdating   = 0.
-      timeValout     = 0.
+      call initTimers()   ! used to be done here, but needs to be called from restarting too when stst1 not called
+
       do 60 i   = 1, maxlv
          tvoll(i) = 0.d0
          iregridcount(i) = 0
@@ -94,6 +83,34 @@ c
       go to 70
  80   continue
 
+
+      return
+      end
+c
+c -------------------------------------------------------------------------
+c
+      subroutine initTimers()
+
+      use amr_module
+      !implicit double precision (a-h,o-z)
+
+      timeBufnst         = 0
+      timeStepgrid       = 0
+      timeStepgridCPU    = 0.d0
+      timeBound          = 0
+      timeBoundCPU       = 0.d0
+      timeGrdfitAll      = 0
+      timeFlagger        = 0
+      timeFlglvl         = 0
+      timeFlglvlTot      = 0
+      timeGrdfit2        = 0
+      timeRegridding     = 0
+      timeRegriddingCPU  = 0.d0
+      timeTick           = 0
+      timeTickCPU        = 0.d0
+      timeUpdating       = 0
+      timeValout         = 0
+      timeValoutCPU      = 0.d0
 
       return
       end

--- a/src/2d/stst1.f
+++ b/src/2d/stst1.f
@@ -100,7 +100,6 @@ c
       use amr_module
       !implicit double precision (a-h,o-z)
 
-      timeFlagger        = 0
       timeBufnst         = 0
       timeStepgrid       = 0
       timeStepgridCPU    = 0.d0

--- a/src/3d/amr_module.f90
+++ b/src/3d/amr_module.f90
@@ -131,7 +131,7 @@ module amr_module
     integer iregridcount(maxlv), tvoll(maxlv)
     integer lentot,lenmax,lendim
     integer timeRegridding, timeValout
-    integer timeBound, timeStepgrid, timeSetaux
+    integer timeBound, timeStepgrid
     integer :: timeTick, tick_clock_start
     real(kind=8) tvollCPU(maxlv)
     real(kind=8) timeBoundCPU,timeStepgridCPU,timeRegriddingCPU

--- a/src/3d/stst1.f
+++ b/src/3d/stst1.f
@@ -63,6 +63,8 @@ c
 c after kcheck integrations of parent grid, move its refinements.
 c finest level grid never needs to have its finer subgrids moved.
 c
+      call initTimers()   ! used to be done here, but needs to be called from restarting too when stst1 not called
+
       do 60 i   = 1, maxlv
          tvoll(i) = 0.d0
          iregridcount(i) = 0
@@ -83,6 +85,26 @@ c
       go to 70
  80   continue
 
+
+      return
+      end
+c
+c -------------------------------------------------------------------------
+c
+      subroutine initTimers()
+
+      use amr_module
+      !implicit double precision (a-h,o-z)
+
+      timeStepgrid       = 0
+      timeStepgridCPU    = 0.d0
+      timeBound          = 0
+      timeBoundCPU       = 0.d0
+      timeRegridding     = 0
+      timeRegriddingCPU  = 0.d0
+      timeTick           = 0
+      timeValout         = 0
+      timeValoutCPU      = 0.d0
 
       return
       end


### PR DESCRIPTION
Now they are all initialized consistently in an `initTimers` subroutine, but they are not all used consistently (some not at all) between the different 1d, 2d, 3d cases.