### PR TITLE
Check for timing file and create if not there

### DIFF
--- a/src/1d/valout.f90
+++ b/src/1d/valout.f90
@@ -260,7 +260,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! Write out timing stats
     ! Assume that this has been started some where
     inquire(file=timing_file_name, exist=timing_file_exists)
-    if (.not. timing_file_exists) then
+    if (frame == 0 .or. (.not. timing_file_exists)) then
         ! Write header out and continue
         open(unit=out_unit, file=timing_file_name, form='formatted',         &
              status='unknown', action='write')

--- a/src/1d/valout.f90
+++ b/src/1d/valout.f90
@@ -25,6 +25,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     real(kind=8), intent(in) :: time
 
     ! Locals
+    logical :: timing_file_exists
     integer, parameter :: out_unit = 50
     integer :: i, j, m, level, output_aux_num, num_stop, digit
     integer :: grid_ptr, num_cells, num_grids, q_loc, aux_loc
@@ -258,7 +259,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! ==========================================================================
     ! Write out timing stats
     ! Assume that this has been started some where
-    if (frame == 0) then
+    inquire(file=timing_file_name, exist=timing_file_exists)
+    if (.not. timing_file_exists) then
         ! Write header out and continue
         open(unit=out_unit, file=timing_file_name, form='formatted',         &
              status='unknown', action='write')
@@ -314,16 +316,14 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
 
 contains
 
-    !
-    !
+    ! Index into q array
     pure integer function iadd(m, i)
         implicit none
         integer, intent(in) :: m, i
         iadd = q_loc + m - 1 + num_eqn * (i - 1)
     end function iadd
 
-    !
-    !
+    ! Index into aux array
     pure integer function iaddaux(m, i)
         implicit none
         integer, intent(in) :: m, i

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -113,6 +113,13 @@ program amr2
     real(kind=8) ::ttotalcpu, cpu_start,cpu_finish 
     integer :: clock_start, clock_finish, clock_rate
     integer, parameter :: timing_unit = 48
+    integer, parameter :: out_unit = 67
+    character(len=256) :: timing_line, timing_substr
+    character(len=*), parameter :: timing_file_name = "timing.csv"
+    character(len=*), parameter :: timing_header_format =                      &
+                                                  "(' wall time (', i2,')," // &
+                                                  " CPU time (', i2,'), "   // &
+                                                  "cells updated (', i2,'),')"
 
 #ifdef HDF5
     ! HDF5 Output
@@ -482,7 +489,20 @@ program amr2
         call set_regions()
         call set_gauges(rest, nvar, naux)
 
-    else
+    else        
+
+        ! Create new timing file
+        open(unit=out_unit, file=timing_file_name, form='formatted',         &
+             status='unknown', action='write')
+        ! Construct header string
+        timing_line = 'output_time,total_wall_time,total_cpu_time,'
+        timing_substr = ""
+        do level=1, mxnest
+            write(timing_substr, timing_header_format) level, level, level
+            timing_line = trim(timing_line) // trim(timing_substr)
+        end do
+        write(out_unit, "(a)") timing_line
+        close(out_unit)
 
         open(outunit, file=outfile, status='unknown', form='formatted')
 

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -1,4 +1,4 @@
-!> Output the results for a general system of conservation laws
+!! Output the results for a general system of conservation laws
 !! in 2 dimensions
 !!
 !! Write the results to the file fort.q<iframe>
@@ -26,6 +26,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     real(kind=8), intent(in) :: time
 
     ! Locals
+    logical :: timing_file_exists
     integer, parameter :: out_unit = 50
     integer :: i, j, m, level, output_aux_num, num_stop, digit, num_dim
     integer :: grid_ptr, num_cells(2), num_grids, q_loc, aux_loc
@@ -367,7 +368,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! ==========================================================================
     ! Write out timing stats
     ! Assume that this has been started some where
-    if (frame == 0) then
+    inquire(file=timing_file_name, exist=timing_file_exists)
+    if (.not. timing_file_exists) then
         ! Write header out and continue
         open(unit=out_unit, file=timing_file_name, form='formatted',         &
              status='unknown', action='write')

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -69,10 +69,6 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
                                            "i6,'                 naux'/,"   // &
                                            "i6,'                 ndim'/,"   // &
                                            "i6,'                 nghost'/,/)"
-    character(len=*), parameter :: timing_header_format =                      &
-                                                  "(' wall time (', i2,')," // &
-                                                  " CPU time (', i2,'), "   // &
-                                                  "cells updated (', i2,'),')"
     character(len=*), parameter :: console_format = &
              "('AMRCLAW: Frame ',i4,' output files done at time t = ', d13.6,/)"
 
@@ -367,24 +363,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
 
     ! ==========================================================================
     ! Write out timing stats
-    ! Assume that this has been started some where
-    inquire(file=timing_file_name, exist=timing_file_exists)
-    if (frame == 0 .or. (.not. timing_file_exists)) then
-        ! Write header out and continue
-        open(unit=out_unit, file=timing_file_name, form='formatted',         &
-             status='unknown', action='write')
-        ! Construct header string
-        timing_line = 'output_time,total_wall_time,total_cpu_time,'
-        timing_substr = ""
-        do level=1, mxnest
-            write(timing_substr, timing_header_format) level, level, level
-            timing_line = trim(timing_line) // trim(timing_substr)
-        end do
-        write(out_unit, "(a)") timing_line
-    else
-        open(unit=out_unit, file=timing_file_name, form='formatted',         &
+    open(unit=out_unit, file=timing_file_name, form='formatted',         &
              status='old', action='write', position='append')
-    end if
     
     timing_line = "(e16.6, ', ', e16.6, ', ', e16.6,"
     do level=1, mxnest

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -369,7 +369,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! Write out timing stats
     ! Assume that this has been started some where
     inquire(file=timing_file_name, exist=timing_file_exists)
-    if (.not. timing_file_exists) then
+    if (frame == 0 .or. (.not. timing_file_exists)) then
         ! Write header out and continue
         open(unit=out_unit, file=timing_file_name, form='formatted',         &
              status='unknown', action='write')

--- a/src/3d/valout.f90
+++ b/src/3d/valout.f90
@@ -27,6 +27,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     real(kind=8), intent(in) :: time
 
     ! Locals
+    logical :: timing_file_exists
     integer, parameter :: out_unit = 50
     integer :: i, j, k, m, level, output_aux_num, num_stop, digit
     integer :: grid_ptr, num_cells(3), num_grids, q_loc, aux_loc
@@ -297,7 +298,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! ==========================================================================
     ! Write out timing stats
     ! Assume that this has been started some where
-    if (frame == 0) then
+    inquire(file=timing_file_name, exist=timing_file_exists)
+    if (.not. timing_file_exists) then
         ! Write header out and continue
         open(unit=out_unit, file=timing_file_name, form='formatted',         &
              status='unknown', action='write')
@@ -353,8 +355,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
 
 contains
 
-    !
-    !
+    ! Index into q array
     pure integer function iadd(m, i, j, k)
         implicit none
         integer, intent(in) :: m, i, j, k
@@ -364,8 +365,7 @@ contains
                        (num_cells(2) + 2 * num_ghost)
     end function iadd
 
-    !
-    !
+    ! Index into aux array
     pure integer function iaddaux(m, i, j, k)
         implicit none
         integer, intent(in) :: m, i, j, k

--- a/src/3d/valout.f90
+++ b/src/3d/valout.f90
@@ -299,7 +299,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! Write out timing stats
     ! Assume that this has been started some where
     inquire(file=timing_file_name, exist=timing_file_exists)
-    if (.not. timing_file_exists) then
+    if (frame == 0 .or. (.not. timing_file_exists)) then
         ! Write header out and continue
         open(unit=out_unit, file=timing_file_name, form='formatted',         &
              status='unknown', action='write')


### PR DESCRIPTION
Minor change to new `valout` timing changes.   Instead of checking for `frame == 0` it checks to see if the timing csv file is present and creates it if necessary.