### PR TITLE
Fix flag2refine

### DIFF
--- a/examples/euler_1d_wcblast/flag2refine1.f90
+++ b/examples/euler_1d_wcblast/flag2refine1.f90
@@ -40,9 +40,10 @@
 !
 ! ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 subroutine flag2refine1(mx,mbc,mbuff,meqn,maux,xlower,dx,t,level, &
-                            tolsp,q,aux,amrflags,DONTFLAG,DOFLAG)
+                            tolsp,q,aux,amrflags)
 
     use regions_module
+    use amr_module, only : DOFLAG, UNSET
 
     implicit none
 
@@ -55,8 +56,6 @@ subroutine flag2refine1(mx,mbc,mbuff,meqn,maux,xlower,dx,t,level, &
     
     ! Flagging
     real(kind=8),intent(inout) :: amrflags(1-mbuff:mx+mbuff)
-    real(kind=8), intent(in) :: DONTFLAG
-    real(kind=8), intent(in) :: DOFLAG
     
     logical :: allowflag
     external allowflag
@@ -64,8 +63,9 @@ subroutine flag2refine1(mx,mbc,mbuff,meqn,maux,xlower,dx,t,level, &
     ! Locals
     integer :: i
 
-    ! Initialize flags
-    amrflags = DONTFLAG
+    ! Don't initialize flags, since they were already 
+    ! flagged by flagregions2
+    ! amrflags = DONTFLAG
     
     ! Loop over interior points on this grid
     ! (i) grid cell is [x_low,x_hi], cell center at (x_c)

--- a/src/1d/flag2refine1.f90
+++ b/src/1d/flag2refine1.f90
@@ -75,9 +75,9 @@ subroutine flag2refine1(mx,mbc,mbuff,meqn,maux,xlower,dx,t,level, &
     ! min_level and max_level specified in any regions.
         
     x_loop: do i = 1,mx
-        x_low = xlower + (i - 1) * dx
-        x_c = xlower + (i - 0.5d0) * dx
-        x_hi = xlower + i * dx
+        !x_low = xlower + (i - 1) * dx
+        !x_c = xlower + (i - 0.5d0) * dx
+        !x_hi = xlower + i * dx
 
         ! -----------------------------------------------------------------
             ! Only check undivided differences if flag hasn't been set yet. 

--- a/src/2d/flag2refine2.f90
+++ b/src/2d/flag2refine2.f90
@@ -90,14 +90,14 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
     ! min_level and max_level specified in any regions.
 
     y_loop: do j=1,my
-        y_low = ylower + (j - 1) * dy
-        y_c = ylower + (j - 0.5d0) * dy
-        y_hi = ylower + j * dy
+        !y_low = ylower + (j - 1) * dy
+        !y_c = ylower + (j - 0.5d0) * dy
+        !y_hi = ylower + j * dy
         
         x_loop: do i = 1,mx
-            x_low = xlower + (i - 1) * dx
-            x_c = xlower + (i - 0.5d0) * dx
-            x_hi = xlower + i * dx
+            !x_low = xlower + (i - 1) * dx
+            !x_c = xlower + (i - 0.5d0) * dx
+            !x_hi = xlower + i * dx
 
             ! -----------------------------------------------------------------
             ! Only check undivided differences if flag hasn't been set yet. 


### PR DESCRIPTION
1. Fixes `examples/euler_1d_wcblast/flag2refine1.f90` due to change in calling sequence introduced in #224.  Fixes problem mentioned in #227.

2. Comment out computation of `x_low, etc.` that are only in the default versions for illustration in case the user needs it for their own version.

3. I notice #224 only updated 1d and 2d codes.  At some point we need to add the same `UNSET` option to the 3d code. I raised #229.