### PR TITLE
Change around logic for creating time files

### DIFF
--- a/src/1d/amr1.f90
+++ b/src/1d/amr1.f90
@@ -112,6 +112,12 @@ program amr1
     integer :: clock_start, clock_finish, clock_rate, ttotal
     real(kind=8) :: cpu_start, cpu_finish,ttotalcpu
     integer, parameter :: timing_unit = 48
+    character(len=256) :: timing_line, timing_substr
+    character(len=*), parameter :: timing_base_name = "timing."
+    character(len=*), parameter :: timing_header_format =                      &
+                                                  "(' wall time (', i2,')," // &
+                                                  " CPU time (', i2,'), "   // &
+                                                  "cells updated (', i2,'),')"
 
     ! Common block variables
     real(kind=8) :: dxmin
@@ -125,7 +131,6 @@ program amr1
     character(len=*), parameter :: dbugfile = 'fort.debug'
     character(len=*), parameter :: matfile = 'fort.nplot'
     character(len=*), parameter :: parmfile = 'fort.parameters'
-    character(len=*), parameter :: timing_file = 'timing.txt'
 
     ! Open parameter and debug files
     open(dbugunit,file=dbugfile,status='unknown',form='formatted')
@@ -439,6 +444,19 @@ program amr1
 
     else
 
+        ! Write header out and continue
+        open(unit=timing_unit, file=timing_base_name//"csv",             &
+             form='formatted', status='unknown', action='write')
+        ! Construct header string
+        timing_line = 'output_time,total_wall_time,total_cpu_time,'
+        timing_substr = ""
+        do level=1, mxnest
+            write(timing_substr, timing_header_format) level, level, level
+            timing_line = trim(timing_line) // trim(timing_substr)
+        end do
+        write(timing_unit, "(a)") timing_line
+        close(timing_unit)
+
         open(outunit, file=outfile, status='unknown', form='formatted')
 
         tstart_thisrun = t0
@@ -559,7 +577,8 @@ program amr1
     
     
     !output timing data
-    open(timing_unit, file=timing_file, status='unknown', form='formatted')
+    open(timing_unit, file=timing_base_name//"txt", status='unknown',       &
+         form='formatted')
     write(*,*)
     write(timing_unit,*)
     format_string="('============================== Timing Data ==============================')"

--- a/src/1d/valout.f90
+++ b/src/1d/valout.f90
@@ -259,23 +259,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! ==========================================================================
     ! Write out timing stats
     ! Assume that this has been started some where
-    inquire(file=timing_file_name, exist=timing_file_exists)
-    if (frame == 0 .or. (.not. timing_file_exists)) then
-        ! Write header out and continue
-        open(unit=out_unit, file=timing_file_name, form='formatted',         &
-             status='unknown', action='write')
-        ! Construct header string
-        timing_line = 'output_time,total_wall_time,total_cpu_time,'
-        timing_substr = ""
-        do level=1, mxnest
-            write(timing_substr, timing_header_format) level, level, level
-            timing_line = trim(timing_line) // trim(timing_substr)
-        end do
-        write(out_unit, "(a)") timing_line
-    else
-        open(unit=out_unit, file=timing_file_name, form='formatted',         &
-             status='old', action='write', position='append')
-    end if
+    open(unit=out_unit, file=timing_file_name, form='formatted',         &
+         status='old', action='write', position='append')
     
     timing_line = "(e16.6, ', ', e16.6, ', ', e16.6,"
     do level=1, mxnest

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -113,9 +113,8 @@ program amr2
     real(kind=8) ::ttotalcpu, cpu_start,cpu_finish 
     integer :: clock_start, clock_finish, clock_rate
     integer, parameter :: timing_unit = 48
-    integer, parameter :: out_unit = 67
     character(len=256) :: timing_line, timing_substr
-    character(len=*), parameter :: timing_file_name = "timing.csv"
+    character(len=*), parameter :: timing_base_name = "timing."
     character(len=*), parameter :: timing_header_format =                      &
                                                   "(' wall time (', i2,')," // &
                                                   " CPU time (', i2,'), "   // &
@@ -138,7 +137,6 @@ program amr2
     character(len=*), parameter :: dbugfile = 'fort.debug'
     character(len=*), parameter :: matfile = 'fort.nplot'
     character(len=*), parameter :: parmfile = 'fort.parameters'
-    character(len=*), parameter :: timing_file = 'timing.txt'
 
     ! Open parameter and debug files
     open(dbugunit,file=dbugfile,status='unknown',form='formatted')
@@ -492,8 +490,8 @@ program amr2
     else        
 
         ! Create new timing file
-        open(unit=out_unit, file=timing_file_name, form='formatted',         &
-             status='unknown', action='write')
+        open(unit=timing_unit, file=timing_base_name//"csv",                &
+             form='formatted', status='unknown', action='write')
         ! Construct header string
         timing_line = 'output_time,total_wall_time,total_cpu_time,'
         timing_substr = ""
@@ -501,8 +499,8 @@ program amr2
             write(timing_substr, timing_header_format) level, level, level
             timing_line = trim(timing_line) // trim(timing_substr)
         end do
-        write(out_unit, "(a)") timing_line
-        close(out_unit)
+        write(timing_unit, "(a)") timing_line
+        close(timing_unit)
 
         open(outunit, file=outfile, status='unknown', form='formatted')
 
@@ -628,7 +626,8 @@ program amr2
     call cpu_time(cpu_finish)
 
     !output timing data
-    open(timing_unit, file=timing_file, status='unknown', form='formatted')
+    open(timing_unit, file=timing_base_name//"txt", status='unknown',       &
+         form='formatted')
     write(*,*)
     write(timing_unit,*)
     format_string="('============================== Timing Data ==============================')"
@@ -676,8 +675,6 @@ program amr2
     format_string="('All levels:')"
     write(*,format_string)
     write(timing_unit,format_string)
-    
-    
     
     !stepgrid
     format_string="('stepgrid      ',1f15.3,'        ',1f15.3,'    ',e17.3)"

--- a/src/3d/amr3.f90
+++ b/src/3d/amr3.f90
@@ -112,6 +112,12 @@ program amr3
     integer :: clock_start, clock_finish, clock_rate, ttotal
     real(kind=8) :: cpu_start, cpu_finish,ttotalcpu
     integer, parameter :: timing_unit = 48
+    character(len=256) :: timing_line, timing_substr
+    character(len=*), parameter :: timing_base_name = "timing."
+    character(len=*), parameter :: timing_header_format =                      &
+                                                  "(' wall time (', i2,')," // &
+                                                  " CPU time (', i2,'), "   // &
+                                                  "cells updated (', i2,'),')"
 
     ! Common block variables
     real(kind=8) :: dxmin, dymin, dzmin
@@ -125,7 +131,6 @@ program amr3
     character(len=*), parameter :: dbugfile = 'fort.debug'
     character(len=*), parameter :: matfile  = 'fort.nplot'
     character(len=*), parameter :: parmfile = 'fort.parameters'
-    character(len=*), parameter :: timing_file = 'timing.txt'
 
     ! Open parameter and debug files
     open(dbugunit,file=dbugfile,status='unknown',form='formatted')
@@ -478,6 +483,18 @@ program amr3
 
         call set_gauges(rest, nvar, naux)
     else
+        ! Write header out and continue
+        open(unit=timing_unit, file=timing_base_name//"csv",            &
+             form='formatted', status='unknown', action='write')
+        ! Construct header string
+        timing_line = 'output_time,total_wall_time,total_cpu_time,'
+        timing_substr = ""
+        do level=1, mxnest
+            write(timing_substr, timing_header_format) level, level, level
+            timing_line = trim(timing_line) // trim(timing_substr)
+        end do
+        write(timing_unit, "(a)") timing_line
+        close(timing_unit)
 
         open(outunit, file=outfile, status='unknown', form='formatted')
 
@@ -608,7 +625,8 @@ program amr3
     call cpu_time(cpu_finish)
     
     !output timing data
-    open(timing_unit, file=timing_file, status='unknown', form='formatted')
+    open(timing_unit, file=timing_base_name//"txt", status='unknown',        &
+         form='formatted')
     write(*,*)
     write(timing_unit,*)
     format_string="('============================== Timing Data ==============================')"

--- a/src/3d/valout.f90
+++ b/src/3d/valout.f90
@@ -298,23 +298,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     ! ==========================================================================
     ! Write out timing stats
     ! Assume that this has been started some where
-    inquire(file=timing_file_name, exist=timing_file_exists)
-    if (frame == 0 .or. (.not. timing_file_exists)) then
-        ! Write header out and continue
-        open(unit=out_unit, file=timing_file_name, form='formatted',         &
-             status='unknown', action='write')
-        ! Construct header string
-        timing_line = 'output_time,total_wall_time,total_cpu_time,'
-        timing_substr = ""
-        do level=1, mxnest
-            write(timing_substr, timing_header_format) level, level, level
-            timing_line = trim(timing_line) // trim(timing_substr)
-        end do
-        write(out_unit, "(a)") timing_line
-    else
-        open(unit=out_unit, file=timing_file_name, form='formatted',         &
+    open(unit=out_unit, file=timing_file_name, form='formatted',           &
              status='old', action='write', position='append')
-    end if
     
     timing_line = "(e16.6, ', ', e16.6, ', ', e16.6,"
     do level=1, mxnest


### PR DESCRIPTION
Basically move the creation of the 'timing.csv' files to `amr*.f90`.  Also removes the 1D code from the 2D stuff given that we have an explicit 1D code now (supercedes #223).