### PR TITLE
add log, __pycache__, and ipynb_checkpoints to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,12 @@ xgeoclaw
 _output/
 _plots/
 *~
+
+# log files
+*.log
+
+# py3k cache directories
+__pycache__
+
+# ipython
+.ipynb_checkpoints


### PR DESCRIPTION
Quick change to the gitignore to exclude a number of files that frequently pop up during our runs & analysis. If you all are in favor, I'm ready to submit identical PRs for all the clawpack submodules.