### PR TITLE
Expand timings.csv header length

### DIFF
--- a/src/1d/amr1.f90
+++ b/src/1d/amr1.f90
@@ -112,7 +112,7 @@ program amr1
     integer :: clock_start, clock_finish, clock_rate, ttotal
     real(kind=8) :: cpu_start, cpu_finish,ttotalcpu
     integer, parameter :: timing_unit = 48
-    character(len=256) :: timing_line, timing_substr
+    character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_base_name = "timing."
     character(len=*), parameter :: timing_header_format =                      &
                                                   "(' wall time (', i2,')," // &

--- a/src/1d/valout.f90
+++ b/src/1d/valout.f90
@@ -37,7 +37,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     integer :: clock_start, clock_finish, clock_rate
     integer    tick_clock_finish, tick_clock_rate, timeTick_int
     real(kind=8) :: cpu_start, cpu_finish, t_CPU_overall, timeTick_overall
-    character(len=256) :: timing_line, timing_substr
+    character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_file_name = "timing.csv"
 
     character(len=*), parameter :: header_format =                             &

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -113,7 +113,7 @@ program amr2
     real(kind=8) ::ttotalcpu, cpu_start,cpu_finish 
     integer :: clock_start, clock_finish, clock_rate
     integer, parameter :: timing_unit = 48
-    character(len=256) :: timing_line, timing_substr
+    character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_base_name = "timing."
     character(len=*), parameter :: timing_header_format =                      &
                                                   "(' wall time (', i2,')," // &

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -45,7 +45,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     integer :: clock_start, clock_finish, clock_rate
     integer    tick_clock_finish, tick_clock_rate, timeTick_int
     real(kind=8) :: cpu_start, cpu_finish, t_CPU_overall, timeTick_overall
-    character(len=256) :: timing_line, timing_substr
+    character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_file_name = "timing.csv"
 
     character(len=*), parameter :: header_format_2d =                          &

--- a/src/3d/amr3.f90
+++ b/src/3d/amr3.f90
@@ -112,7 +112,7 @@ program amr3
     integer :: clock_start, clock_finish, clock_rate, ttotal
     real(kind=8) :: cpu_start, cpu_finish,ttotalcpu
     integer, parameter :: timing_unit = 48
-    character(len=256) :: timing_line, timing_substr
+    character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_base_name = "timing."
     character(len=*), parameter :: timing_header_format =                      &
                                                   "(' wall time (', i2,')," // &

--- a/src/3d/valout.f90
+++ b/src/3d/valout.f90
@@ -39,7 +39,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     integer :: clock_start, clock_finish, clock_rate
     integer    tick_clock_finish, tick_clock_rate, timeTick_int
     real(kind=8) :: cpu_start, cpu_finish, t_CPU_overall, timeTick_overall
-    character(len=256) :: timing_line, timing_substr
+    character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_file_name = "timing.csv"
 
     character(len=*), parameter :: header_format =                             &


### PR DESCRIPTION
Minor fix to timings headers to make them long enough to handle more than 4 levels of refinement.