### PR TITLE
update adjoint write method

### DIFF
--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -416,6 +416,9 @@ class AdjointData(clawpack.clawutil.data.ClawData):
         self.data_write('numadjoints')
             
         for file in self.adjoint_files:
+            # if path is relative in setrun, assume it's relative to the
+            # same directory that out_file comes from
+            fname = os.path.abspath(os.path.join(os.path.dirname(out_file),file))
             self._out_file.write("'%s'\n" % file)
         self.close_data_file()
 

--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -419,7 +419,7 @@ class AdjointData(clawpack.clawutil.data.ClawData):
             # if path is relative in setrun, assume it's relative to the
             # same directory that out_file comes from
             fname = os.path.abspath(os.path.join(os.path.dirname(out_file),file))
-            self._out_file.write("'%s'\n" % file)
+            self._out_file.write("'%s'\n" % fname)
         self.close_data_file()
 
     def set_adjoint_files(self):


### PR DESCRIPTION
updates the write method for AdjointData so that it if the setrun file references adjoint files with a relative path, they are assumed to be relative to the directory where you are writing the `AdjointData` object out.

This PR goes with https://github.com/clawpack/clawutil/pull/136