### PR TITLE
Change passing aux value limits

### DIFF
--- a/src/1d/advanc.f
+++ b/src/1d/advanc.f
@@ -238,7 +238,7 @@ c     no more,  each gauge has own array.
 
       if (num_gauges > 0) then
            call update_gauges(alloc(locnew:locnew+nvar*mitot),
-     .                       alloc(locaux:locaux+nvar*mitot),
+     .                       alloc(locaux:locaux+naux*mitot),
      .                       xlow,nvar,mitot,naux,mptr)
          endif
 

--- a/src/2d/advanc.f
+++ b/src/2d/advanc.f
@@ -248,7 +248,7 @@ c     no more,  each gauge has own array.
 
       if (num_gauges > 0) then
            call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot),
-     .                       alloc(locaux:locaux+nvar*mitot*mjtot),
+     .                       alloc(locaux:locaux+naux*mitot*mjtot),
      .                       xlow,ylow,nvar,mitot,mjtot,naux,mptr)
          endif
 

--- a/src/3d/advanc.f
+++ b/src/3d/advanc.f
@@ -253,7 +253,7 @@ c     should change the way print_gauges does io - right now is critical section
 
       if (num_gauges > 0) then
          call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot*mktot),
-     .                     alloc(locaux:locaux+nvar*mitot*mjtot*mktot),
+     .                     alloc(locaux:locaux+naux*mitot*mjtot*mktot),
      .                     xlow,ylow,zlow,nvar,mitot,mjtot,mktot,
      .                     naux,mptr)
          endif


### PR DESCRIPTION
Fix a bug pointed out in clawpack/geoclaw#402 and extends this to all the AMRClaw routines.