### PR TITLE
improving timing with 8 byte integers

### DIFF
--- a/examples/advection_2d_swirl/setplot.py
+++ b/examples/advection_2d_swirl/setplot.py
@@ -88,6 +88,30 @@ def setplot(plotdata=None):
     plotitem.plotstyle = 'b-'
 
     #-----------------------------------------
+    # Plots of timing (CPU and wall time):
+
+    def make_timing_plots(plotdata):
+        from clawpack.visclaw import plot_timing_stats
+        import os,sys
+        try:
+            timing_plotdir = plotdata.plotdir + '/_timing_figures'
+            os.system('mkdir -p %s' % timing_plotdir)
+            # adjust units for plots based on problem:
+            units = {'comptime':'seconds', 'simtime':'dimensionless', 
+                     'cell':'millions'}
+            plot_timing_stats.make_plots(outdir=plotdata.outdir, 
+                                          make_pngs=True,
+                                          plotdir=timing_plotdir, 
+                                          units=units)
+        except:
+            print('*** Error making timing plots')
+
+    otherfigure = plotdata.new_otherfigure(name='timing plots',
+                    fname='_timing_figures/timing.html')
+    otherfigure.makefig = make_timing_plots
+
+    #-----------------------------------------
+
 
     # Parameters used only when creating html and/or latex hardcopy
     # e.g., via clawpack.visclaw.frametools.printframes:

--- a/examples/euler_2d_quadrants/setplot.py
+++ b/examples/euler_2d_quadrants/setplot.py
@@ -106,6 +106,31 @@ def setplot(plotdata=None):
     plotitem.plotstyle = 'b-'
 
 
+    #-----------------------------------------
+    # Plots of timing (CPU and wall time):
+
+    def make_timing_plots(plotdata):
+        from clawpack.visclaw import plot_timing_stats
+        import os,sys
+        try:
+            timing_plotdir = plotdata.plotdir + '/_timing_figures'
+            os.system('mkdir -p %s' % timing_plotdir)
+            # adjust units for plots based on problem:
+            units = {'comptime':'seconds', 'simtime':'dimensionless', 
+                     'cell':'millions'}
+            plot_timing_stats.make_plots(outdir=plotdata.outdir, 
+                                          make_pngs=True,
+                                          plotdir=timing_plotdir, 
+                                          units=units)
+        except:
+            print('*** Error making timing plots')
+
+    otherfigure = plotdata.new_otherfigure(name='timing plots',
+                    fname='_timing_figures/timing.html')
+    otherfigure.makefig = make_timing_plots
+
+    #-----------------------------------------
+
     # Parameters used only when creating html and/or latex hardcopy
     # e.g., via clawpack.visclaw.frametools.printframes:
 

--- a/src/2d/advanc.f
+++ b/src/2d/advanc.f
@@ -17,8 +17,9 @@ c
       integer omp_get_thread_num, omp_get_max_threads
       integer mythread/0/, maxthreads/1/
       integer listgrids(numgrids(level))
-      integer clock_start, clock_finish, clock_rate
-      integer clock_startStepgrid,clock_startBound,clock_finishBound
+      integer(kind=8) :: clock_start, clock_finish, clock_rate
+      integer(kind=8) :: clock_startStepgrid,clock_startBound,
+     &                   clock_finishBound
       real(kind=8) cpu_start, cpu_finish
       real(kind=8) cpu_startBound, cpu_finishBound
       real(kind=8) cpu_startStepgrid, cpu_finishStepgrid

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -113,7 +113,7 @@ program amr2
     ! Timing variables
     integer ::  ttotal
     real(kind=8) ::ttotalcpu, cpu_start,cpu_finish 
-    integer :: clock_start, clock_finish, clock_rate
+    integer(kind=8) :: clock_start, clock_finish, clock_rate
     integer, parameter :: timing_unit = 48
     character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_base_name = "timing."

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -111,9 +111,9 @@ program amr2
     logical :: vtime, rest, output_t0    
 
     ! Timing variables
-    integer ::  ttotal
-    real(kind=8) ::ttotalcpu, cpu_start,cpu_finish 
-    integer(kind=8) :: clock_start, clock_finish, clock_rate
+    integer(kind=8) ::  ttotal
+    real(kind=8) ::ttotalcpu
+    integer(kind=8) :: clock_start, clock_finish, clock_rate, count_max
     integer, parameter :: timing_unit = 48
     character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_base_name = "timing."
@@ -617,7 +617,7 @@ program amr2
     close(parmunit)
 
     ! Timing:  moved inside tick so can finish and be checkpointed
-    call cpu_time(cpu_start)
+    ! use clock_start and clock_finish here only for debug output:
     call system_clock(clock_start,clock_rate)
 
     ! --------------------------------------------------------
@@ -627,7 +627,8 @@ program amr2
     call tick(nvar,cut,nstart,vtime,time,naux,t0,rest,dt_max)
     ! --------------------------------------------------------
 
-    call cpu_time(cpu_finish)
+    ! call system_clock to get clock_rate and count_max:
+    call system_clock(clock_finish,clock_rate,count_max)
 
     !output timing data
     open(timing_unit, file=timing_base_name//"txt", status='unknown',       &
@@ -650,11 +651,14 @@ program amr2
     format_string="('Level           Wall Time (seconds)    CPU Time (seconds)   Total Cell Updates')"
     write(timing_unit,format_string)
     write(*,format_string)
-    ttotalcpu=0.d0
-    ttotal=0
+    if (rest) then
+        ttotalcpu=timeTickCPU
+        ttotal=timeTick
+      else
+        ttotalcpu=0.d0
+        ttotal=0
+      endif
 
-    call system_clock(clock_finish,clock_rate)  ! just to get clock_rate
-    write(*,*) "clock_rate ",clock_rate
 
     do level=1,mxnest
         format_string="(i3,'           ',1f15.3,'        ',1f15.3,'    ', e17.3)"
@@ -714,9 +718,6 @@ program amr2
     !Total Time
     format_string="('Total time:   ',1f15.3,'        ',1f15.3,'  ')"
 
-!    write(*,format_string)  &
-!            real(clock_finish - clock_start,kind=8) / real(clock_rate,kind=8), &
-!            cpu_finish-cpu_start
     write(*,format_string) real(timeTick,kind=8)/real(clock_rate,kind=8), &
             timeTickCPU
     write(timing_unit,format_string) real(timeTick,kind=8)/real(clock_rate,kind=8), &
@@ -746,15 +747,26 @@ program amr2
     write(timing_unit, "('      in the file timing.csv.')")
     
     
-    !end of timing data
     write(*,*)
     write(timing_unit,*)
+
+    ! output clock_rate etc. useful in debugging or if negative time reported
+
+    format_string="('clock_rate = ',i10, ' per second,  count_max = ',i23)"
+    !write(*,format_string) clock_rate, count_max
+    write(timing_unit,format_string) clock_rate, count_max
+
+    format_string="('clock_start = ',i20, ',  clock_finish = ',i20)"
+    !write(*,format_string) clock_start, clock_finish
+    write(timing_unit,format_string) clock_start, clock_finish
+
     format_string="('=========================================================================')"
     write(timing_unit,format_string)
     write(*,format_string)
     write(*,*)
     write(timing_unit,*)
     close(timing_unit)
+    !end of timing data
 
     ! Done with computation, cleanup:
     lentotsave = lentot

--- a/src/2d/amr_module.f90
+++ b/src/2d/amr_module.f90
@@ -253,7 +253,7 @@ module amr_module
     integer(kind=8) :: timeFlglvl,timeGrdfit2,timeGrdfit3,timeGrdfitAll
     integer(kind=8) :: timeBound,timeStepgrid
     integer(kind=8) :: timeFlagger, timeBufnst,timeTick, tick_clock_start
-    real(kind=8) tvollCPU(maxlv), timeTickCPU
+    real(kind=8) tvollCPU(maxlv), timeTickCPU, tick_cpu_start
     real(kind=8) timeBoundCPU,timeStepgridCPU,timeRegriddingCPU
     real(kind=8) timeValoutCPU
 

--- a/src/2d/amr_module.f90
+++ b/src/2d/amr_module.f90
@@ -247,11 +247,12 @@ module amr_module
     ! :::::  collect stats
     ! ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
     real(kind=8)  rvoll(maxlv),evol,rvol,avenumgrids(maxlv)
-    integer ::  iregridcount(maxlv), tvoll(maxlv)
-    integer :: timeRegridding, timeUpdating, timeValout
-    integer :: timeFlglvl,timeGrdfit2,timeGrdfit3,timeGrdfitAll
-    integer :: timeBound,timeStepgrid
-    integer :: timeFlagger, timeBufnst,timeTick, tick_clock_start
+    integer ::  iregridcount(maxlv)
+    integer(kind=8) ::  tvoll(maxlv)
+    integer(kind=8) :: timeRegridding, timeUpdating, timeValout
+    integer(kind=8) :: timeFlglvl,timeGrdfit2,timeGrdfit3,timeGrdfitAll
+    integer(kind=8) :: timeBound,timeStepgrid
+    integer(kind=8) :: timeFlagger, timeBufnst,timeTick, tick_clock_start
     real(kind=8) tvollCPU(maxlv), timeTickCPU
     real(kind=8) timeBoundCPU,timeStepgridCPU,timeRegriddingCPU
     real(kind=8) timeValoutCPU

--- a/src/2d/filpatch.f90
+++ b/src/2d/filpatch.f90
@@ -98,7 +98,7 @@ recursive subroutine filrecur(level,nvar,valbig,aux,naux,t,mitot,mjtot, &
   real(kind=8) :: xcent_fine, xcent_coarse, ycent_fine, ycent_coarse,ratiox,ratioy,floor    
 
   !for timing
-  integer :: clock_start, clock_finish, clock_rate
+  integer(kind=8) :: clock_start, clock_finish, clock_rate
   real(kind=8) :: cpu_start, cpu_finish
 
   ! Interpolation variables

--- a/src/2d/filval.f90
+++ b/src/2d/filval.f90
@@ -32,7 +32,7 @@ subroutine filval(val, mitot, mjtot, dx, dy, level, time,  mic,          &
     logical :: sticksoutxfine, sticksoutyfine,sticksoutxcrse,sticksoutycrse
     
     !for setaux timing
-    integer :: clock_start, clock_finish, clock_rate
+    integer(kind=8) :: clock_start, clock_finish, clock_rate
     real(kind=8) :: cpu_start, cpu_finish
 
 

--- a/src/2d/flglvl2.f
+++ b/src/2d/flglvl2.f
@@ -26,7 +26,7 @@ c
 c
       use amr_module
       implicit double precision (a-h,o-z)
-      integer clock_start, clock_finish, clock_rate
+      integer(kind=8) :: clock_start, clock_finish, clock_rate
 c
 c
 c

--- a/src/2d/grdfit2.f
+++ b/src/2d/grdfit2.f
@@ -22,8 +22,8 @@ c
 c
       use amr_module
       implicit double precision (a-h,o-z)
-      integer clock_start, clock_finish, clock_rate
-      integer clock_start1
+      integer(kind=8) :: clock_start, clock_finish, clock_rate
+      integer(kind=8) :: clock_start1
 c
       dimension  corner(nsize,maxcl)
       integer    numptc(maxcl), prvptr

--- a/src/2d/regrid.f
+++ b/src/2d/regrid.f
@@ -6,7 +6,7 @@ c
       use amr_module
       implicit double precision (a-h,o-z)
       integer newnumgrids(maxlv)
-      integer clock_start2, clock_finish, clock_rate
+      integer(kind=8) :: clock_start2, clock_finish, clock_rate
 c
 c :::::::::::::::::::::::::::: REGRID :::::::::::::::::::::::::::::::
 

--- a/src/2d/tick.f
+++ b/src/2d/tick.f
@@ -16,7 +16,7 @@ c     include  "call.i"
       dimension dtnew(maxlv), ntogo(maxlv), tlevel(maxlv)
       integer(kind=8) ::   clock_start, clock_finish, clock_rate
       integer(kind=8) ::   tick_clock_finish, tick_clock_rate  
-
+      real(kind=8) :: cpu_start,cpu_finish
 
 c
 c :::::::::::::::::::::::::::: TICK :::::::::::::::::::::::::::::
@@ -45,8 +45,6 @@ c          each step) to keep track of when that level should
 c          have its error estimated and finer levels should be regridded.
 c ::::::::::::::::::::::::::::::::::::;::::::::::::::::::::::::::
 c
-      call system_clock(tick_clock_start,tick_clock_rate)
-      call cpu_time(tick_cpu_start)
 
 
       ncycle         = nstart

--- a/src/2d/tick.f
+++ b/src/2d/tick.f
@@ -14,8 +14,8 @@ c     include  "call.i"
       logical    vtime, dumpout/.false./, dumpchk/.false./
       logical    rest, dump_final
       dimension dtnew(maxlv), ntogo(maxlv), tlevel(maxlv)
-      integer   clock_start, clock_finish, clock_rate
-      integer   tick_clock_finish, tick_clock_rate  
+      integer(kind=8) ::   clock_start, clock_finish, clock_rate
+      integer(kind=8) ::   tick_clock_finish, tick_clock_rate  
 
 
 c

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -13,7 +13,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: node, rnode, ndilo, ndihi, ndjlo, ndjhi
     use amr_module, only: cornxlo, cornylo, levelptr, mxnest
     use amr_module, only: timeValout, timeValoutCPU, tvoll, tvollCPU, rvoll
-    use amr_module, only: timeTick, tick_clock_start, t0
+    use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
 #ifdef HDF5
     use hdf5
@@ -353,6 +353,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
         timeTick_overall = 0.d0
     else
         call cpu_time(t_CPU_overall)
+        ! if this is a restart, need to adjust add in time from previous run:
+        t_CPU_overall = t_CPU_overall + timeTickCPU
+
         call system_clock(tick_clock_finish,tick_clock_rate)
         timeTick_int = timeTick + tick_clock_finish - tick_clock_start
         timeTick_overall = real(timeTick_int, kind=8)/real(clock_rate,kind=8)

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -42,8 +42,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
 #endif
 
     ! Timing
-    integer :: clock_start, clock_finish, clock_rate
-    integer    tick_clock_finish, tick_clock_rate, timeTick_int
+    integer(kind=8) :: clock_start, clock_finish, clock_rate
+    integer(kind=8) ::    tick_clock_finish, tick_clock_rate, timeTick_int
     real(kind=8) :: cpu_start, cpu_finish, t_CPU_overall, timeTick_overall
     character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_file_name = "timing.csv"


### PR DESCRIPTION
Several updates to how timing is done:

- Wall clock timing done with calls to `system_clock` now pass in 8-byte integers so many integer declarations are now `(kind=8)`.  This has two advantages: Greater granularity when timing things that take only a few ms so that adding up over many calls is perhaps more accurate. More importantly, the `count_max` parameter is much larger so the count does not wrap (which then gives negative elapsed time when subtracting `clock_finish - clock_start`).  This was a frequent problem on long GeoClaw runs on certain computers.

- A fix was added so that CPU time is properly incremented after a restart.  I think that now after a restart the `timing.csv` file should be accurate for both wall times and CPU times.  (Unless of course you restart more than once from the same checkpoint file, since `valout` keeps adding lines to the file).

- Two examples have modified `setplot.py` to plot the timing stats, which requires https://github.com/clawpack/visclaw/pull/247 to work properly (but should fail gracefully otherwise). Sample output from these examples can be viewed at http://staff.washington.edu/rjl/misc/timing_plots/

A corresponding PR will be submitted to GeoClaw.
