### PR TITLE
fix proper nesting bug and reset timers

### DIFF
--- a/src/1d/amr1.f90
+++ b/src/1d/amr1.f90
@@ -439,6 +439,7 @@ program amr1
         print *, ' '
         ! Call user routine to set up problem parameters:
         call setprob()
+        call initTimers() ! better to checkpt and reread but for now set to 0
 
         ! Non-user data files
         call set_regions()

--- a/src/1d/baseCheck.f
+++ b/src/1d/baseCheck.f
@@ -37,7 +37,7 @@ c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
       if (debug) write(outunit,100) mnew,lbase,ilo,ihi,levnew
  100  format("NESTCK1 testing grid ",i5," base level ",i5,/,
-     . " new grid from ilo:hi: ",2i12," to ",2i12," at level ",i4)
+     . " new grid from ilo:hi: (",i12," to ",i12,") at level ",i4)
 c
 c    on to initializing for the given grid and its nest checking
        levratx = 1
@@ -57,8 +57,8 @@ c figure out size for scratch storage on base grid for testing
           ichi = ichi + 1
           if (debug) then
              write(outunit,111) lev, iclo,ichi
-111          format(10x,"at level",i5," projected coords ilo:hi:",2i10,
-     .           " jlo:hi:",2i10)
+111          format(10x,"at level",i5," projected coords ilo:hi:(",
+     &              2i10,")")
           endif
        end do
 c      high end of integer grid index truncates during the divide
@@ -105,6 +105,8 @@ c
               ixlo = max(iclo,iblo)
               ixhi = min(ichi,ibhi)
               if (.not.(ixlo.le.ixhi)) go to 30
+              if (debug) write(outunit,105) ixlo,ixhi
+105           format("marking nested region from: ",2i10)
               do ix = ixlo, ixhi
                 alloc(iadd(ix))=1.
               end do

--- a/src/1d/nestck1.f
+++ b/src/1d/nestck1.f
@@ -36,6 +36,7 @@ c      # for CONVEX coarsest grid at level 1, nothing to check
        levnew = node(nestlevel,mnew)
        lratiox  = intratx(levnew-1)
 
+       zeroBuff = 0 ! dont count buffer zone around grid in checking
        isNested = baseCheck(mnew,lbase,node(ndilo,mnew),
      .                      node(ndihi,mnew),nvar,naux,zeroBuff)
        if (isNested) then

--- a/src/1d/prepbigstep.f
+++ b/src/1d/prepbigstep.f
@@ -62,6 +62,7 @@ c         coarsen by 2 in every direction
           call coarsen(valdub,midub,
      1                 valbgc,mi2tot,nvar)
 
+          cfl_level = 0.d0   ! normally set in advanc
           call stepgrid(valbgc,fm,fp,
      1                mi2tot,nghost,
      2                dt2,dtnew2,hx2,nvar,

--- a/src/1d/stst1.f
+++ b/src/1d/stst1.f
@@ -108,6 +108,8 @@ c
       timeRegriddingCPU  = 0.d0
       timeTick           = 0
       timeTickCPU        = 0.d0
+      timeSetaux         = 0.d0
+      timeSetauxCPU      = 0.d0
       timeUpdating       = 0
       timeValout         = 0
       timeValoutCPU      = 0.d0

--- a/src/1d/tick.f
+++ b/src/1d/tick.f
@@ -197,6 +197,9 @@ c
 
           call system_clock(clock_start,clock_rate)
           call cpu_time(cpu_start)
+c         write(*,*)"at time ",tlevel(lbase)," lbase,lfine",
+c    .              lbase,lfine," about to regrid "
+c         call valout(lbase,lfine,-tlevel(lbase),nvar,naux)
           call regrid(nvar,lbase,cut,naux,start_time)
           call system_clock(clock_finish,clock_rate)
           call cpu_time(cpu_finish)
@@ -206,6 +209,7 @@ c
           call setbestsrc()     ! need at every grid change
 c         call outtre(lstart(lbase+1),.true.,nvar,naux)
 c note negative time to signal regridding output in plots
+c         write(*,*)"after regridding "
 c         call valout(lbase,lfine,-tlevel(lbase),nvar,naux)
 c
 c  maybe finest level in existence has changed. reset counters.


### PR DESCRIPTION
fix proper nesting bug of missing initialization of zeroBuff.
Also reset timers to 0 on restart so could run with debugging flags,
but better to checkpt/restrt in the future