### PR TITLE
Variable max1d

### DIFF
--- a/examples/advection_2d_square/setrun.py
+++ b/examples/advection_2d_square/setrun.py
@@ -270,7 +270,7 @@ def setrun(claw_pkg='amrclaw'):
     amrdata = rundata.amrdata
 
     # max1d controls size of grids
-    amrdata.max1d = 120
+    amrdata.max1d = 60
 
     # max number of refinement levels:
     amrdata.amr_levels_max = 3

--- a/examples/advection_2d_square/setrun.py
+++ b/examples/advection_2d_square/setrun.py
@@ -269,6 +269,7 @@ def setrun(claw_pkg='amrclaw'):
     # ---------------
     amrdata = rundata.amrdata
 
+    # max1d controls size of grids
     amrdata.max1d = 120
 
     # max number of refinement levels:

--- a/examples/advection_2d_square/setrun.py
+++ b/examples/advection_2d_square/setrun.py
@@ -269,6 +269,7 @@ def setrun(claw_pkg='amrclaw'):
     # ---------------
     amrdata = rundata.amrdata
 
+    amrdata.max1d = 120
 
     # max number of refinement levels:
     amrdata.amr_levels_max = 3

--- a/examples/advection_3d_swirl/setrun.py
+++ b/examples/advection_3d_swirl/setrun.py
@@ -277,6 +277,9 @@ def setrun(claw_pkg='amrclaw'):
     # ---------------
     amrdata = rundata.amrdata
 
+    # max1d controls size of grids
+    amrdata.max1d = 32
+
     # max number of refinement levels:
     amrdata.amr_levels_max = 2
 

--- a/examples/advection_3d_swirl/setrun.py
+++ b/examples/advection_3d_swirl/setrun.py
@@ -30,7 +30,7 @@ def setrun(claw_pkg='amrclaw'):
 
     assert claw_pkg.lower() == 'amrclaw',  "Expected claw_pkg = 'amrclaw'"
 
-    num_dim = 3
+    num_dim = 3 
     rundata = data.ClawRunData(claw_pkg, num_dim)
 
     #------------------------------------------------------------------

--- a/examples/euler_1d_wcblast/setrun.py
+++ b/examples/euler_1d_wcblast/setrun.py
@@ -250,7 +250,7 @@ def setrun(claw_pkg='amrclaw'):
     amrdata = rundata.amrdata
 
     # max1d controls size of grids
-    amrdata.max1d = 100
+    amrdata.max1d = 500
 
     # max number of refinement levels:
     amrdata.amr_levels_max = 4

--- a/examples/euler_1d_wcblast/setrun.py
+++ b/examples/euler_1d_wcblast/setrun.py
@@ -249,6 +249,9 @@ def setrun(claw_pkg='amrclaw'):
     
     amrdata = rundata.amrdata
 
+    # max1d controls size of grids
+    amrdata.max1d = 100
+
     # max number of refinement levels:
     amrdata.amr_levels_max = 4
     

--- a/src/1d/amr1.f90
+++ b/src/1d/amr1.f90
@@ -298,6 +298,8 @@ program amr1
     !  Refinement Control
     call opendatafile(inunit, amrfile)
 
+    read(inunit,*) max1d  ! max size of each grid patch
+
     read(inunit,*) mxnest
     if (mxnest <= 0) then
         stop 'Error ***   mxnest (amrlevels_max) <= 0 not allowed'

--- a/src/1d/amr_module.f90
+++ b/src/1d/amr_module.f90
@@ -58,7 +58,8 @@ module amr_module
     ! The max1d parameter controls the number of grid cells in 
     ! any single grid patch before breaking up. 
     ! Might want to set smaller to break up into more patches for OpenMP
-    integer, parameter :: max1d = 500 
+    ! max1d should now be set in setrun.py
+    integer:: max1d
 
     integer, parameter :: maxvar = 10
     integer, parameter :: maxaux = 20

--- a/src/1d/qad.f
+++ b/src/1d/qad.f
@@ -39,11 +39,11 @@ c      # in rp1, but shouldn't matter since wave is not used in qad
 c      # and for other arrays it is only the last parameter that is wrong
 c      #  ok as long as meqn, mwaves < maxvar
 
-       parameter (max1dp1 = max1d+1)
-       dimension ql(nvar,max1dp1),    qr(nvar,max1dp1)
-       dimension wave(nvar,mwaves,max1dp1), s(mwaves,max1dp1)
-       dimension amdq(nvar,max1dp1),  apdq(nvar,max1dp1)
-       dimension auxl(maxaux*max1dp1),  auxr(maxaux*max1dp1)
+       integer  max1dp1
+       dimension ql(nvar,max1d+1),    qr(nvar,max1d+1)
+       dimension wave(nvar,mwaves,max1d+1), s(mwaves,max1d+1)
+       dimension amdq(nvar,max1d+1),  apdq(nvar,max1d+1)
+       dimension auxl(maxaux*(max1d+1)),  auxr(maxaux*(max1d+1))
 c
 c  WARNING: auxl,auxr dimensioned at max possible, but used as if
 c  they were dimensioned as the real maux by max1dp1. Would be better
@@ -59,6 +59,7 @@ c      auxc1d is coarse grid stuff from around boundary, same format as qc1d
 c      auxl, auxr are work arrays needed to pass stuff to rp1
 c      maux is the number of aux variables, which may be zero.
 c
+       max1dp1 = max1d + 1
 
        tgrid = rnode(timemult, mptr)
        if (qprint) 

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -342,6 +342,8 @@ program amr2
     !  Refinement Control
     call opendatafile(inunit, amrfile)
 
+    read(inunit,*) max1d  ! max size of each grid patch
+
     read(inunit,*) mxnest
     if (mxnest <= 0) then
         stop 'Error ***   mxnest (amrlevels_max) <= 0 not allowed'

--- a/src/2d/amr_module.f90
+++ b/src/2d/amr_module.f90
@@ -179,8 +179,8 @@ module amr_module
 
     ! The max1d parameter should be changed if using OpenMP grid based 
     ! looping, usually set to max1d = 60
-    integer, parameter :: max1d = 60 
-    !integer, parameter :: max1d = 650 
+    ! max1d should now be set in setrun.py
+    integer :: max1d
 
     integer, parameter :: maxvar = 10
     integer, parameter :: maxaux = 20

--- a/src/2d/qad.f
+++ b/src/2d/qad.f
@@ -41,15 +41,15 @@ c      # in rp2, but shouldn't matter since wave is not used in qad
 c      # and for other arrays it is only the last parameter that is wrong
 c      #  ok as long as meqn, mwaves < maxvar
 
-       parameter (max1dp1 = max1d+1)
-       dimension ql(nvar,max1dp1),    qr(nvar,max1dp1)
-       dimension wave(nvar,mwaves,max1dp1), s(mwaves,max1dp1)
-       dimension amdq(nvar,max1dp1),  apdq(nvar,max1dp1)
-       dimension auxl(maxaux*max1dp1),  auxr(maxaux*max1dp1)
+       integer max1dp1
+       dimension ql(nvar,max1d+1),    qr(nvar,max1d+1)
+       dimension wave(nvar,mwaves,max1d+1), s(mwaves,max1d+1)
+       dimension amdq(nvar,max1d+1),  apdq(nvar,max1d+1)
+       dimension auxl(maxaux*(max1d+1)),  auxr(maxaux*(max1d+1))
 c
 c  WARNING: auxl,auxr dimensioned at max possible, but used as if
-c  they were dimensioned as the real maux by max1dp1. Would be better
-c  of course to dimension by maux by max1dp1 but this wont work if maux=0
+c  they were dimensioned as the real maux by max1d+1. Would be better
+c  of course to dimension by maux by max1d+1 but this wont work if maux=0
 c  So need to access using your own indexing into auxl,auxr.
        iaddaux(iaux,i) = iaux + maux*(i-1)
 
@@ -61,6 +61,8 @@ c      auxc1d is coarse grid stuff from around boundary, same format as qc1d
 c      auxl, auxr are work arrays needed to pass stuff to rpn2
 c      maux is the number of aux variables, which may be zero.
 c
+
+       max1dp1 = max1d+1
 
        tgrid = rnode(timemult, mptr)
        if (qprint) 

--- a/src/2d/stepgrid.f
+++ b/src/2d/stepgrid.f
@@ -48,14 +48,11 @@ c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
       common /comxyt/ dtcom,dxcom,dycom,tcom,icom,jcom
 
-      parameter (msize=max1d+4)
-      parameter (mwork=msize*(maxvar*maxvar + 13*maxvar + 3*maxaux +2))
 
       dimension q(nvar,mitot,mjtot)
       dimension fp(nvar,mitot,mjtot),gp(nvar,mitot,mjtot)
       dimension fm(nvar,mitot,mjtot),gm(nvar,mitot,mjtot)
       dimension aux(maux,mitot,mjtot)
-c 	  dimension work(mwork)
 
       logical    debug,  dump
       data       debug/.false./,  dump/.false./

--- a/src/2d/stepgrid_dimSplit.f
+++ b/src/2d/stepgrid_dimSplit.f
@@ -31,14 +31,11 @@ c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
       implicit double precision (a-h,o-z)
       external rpn2
 
-      parameter (msize=max1d+4)
-      parameter (mwork=msize*(maxvar*maxvar + 13*maxvar + 3*maxaux +2))
 
       dimension q(nvar,mitot,mjtot)
       dimension fp(nvar,mitot,mjtot),gp(nvar,mitot,mjtot)
       dimension fm(nvar,mitot,mjtot),gm(nvar,mitot,mjtot)
       dimension aux(maux,mitot,mjtot)
-C     dimension work(mwork)
 
       logical    debug,  dump
       data       debug/.false./,  dump/.false./

--- a/src/3d/amr3.f90
+++ b/src/3d/amr3.f90
@@ -330,6 +330,8 @@ program amr3
     !  Refinement Control
     call opendatafile(inunit, amrfile)
 
+    read(inunit,*) max1d  ! max size of each grid patch
+
     read(inunit,*) mxnest
     if (mxnest <= 0) then
         stop 'Error ***   mxnest (amrlevels_max) <= 0 not allowed'

--- a/src/3d/amr_module.f90
+++ b/src/3d/amr_module.f90
@@ -65,7 +65,8 @@ module amr_module
 
     ! The max1d parameter should be changed if using OpenMP grid based 
     ! looping, suggest setting max1d = 32 for 3d 
-    integer, parameter :: max1d = 32 
+    ! max1d should now be set in setrun.py
+    integer:: max1d
     !integer, parameter :: max1d = 28 
 
     integer, parameter :: maxvar = 10

--- a/src/3d/qad.f
+++ b/src/3d/qad.f
@@ -39,12 +39,11 @@ c      # in rp2, but shouldnt matter since wave is not used in qad
 c      # and for other arrays it is only the last parameter that is wrong
 c      #  ok as long as meqn, mwaves < maxvar
 
-       parameter (max1dp1 = max1d+1)
-c      parameter (max1dp1 = (max1d+1)**2+1)
-       dimension ql(nvar,max1dp1),    qr(nvar,max1dp1)
-       dimension wave(nvar,mwaves,max1dp1), s(mwaves,max1dp1)
-       dimension amdq(nvar,max1dp1),  apdq(nvar,max1dp1)
-       dimension auxl(maux,max1dp1),  auxr(maux,max1dp1)
+       integer max1dp1 
+       dimension ql(nvar,max1d+1),    qr(nvar,max1d+1)
+       dimension wave(nvar,mwaves,max1d+1), s(mwaves,max1d+1)
+       dimension amdq(nvar,max1d+1),  apdq(nvar,max1d+1)
+       dimension auxl(maux,max1d+1),  auxr(maux,max1d+1)
 
        data qprint/.false./
 c
@@ -56,6 +55,8 @@ c      maux is the number of aux variables, which may be zero.
 c
 c      nr, nc, nf are the number of rows, columns, files
 c
+
+       max1dp1 = max1d + 1
 
        if (qprint) write(dbugunit,*)" working on grid ",mptr
        tgrid = rnode(timemult, mptr)

--- a/src/3d/stepgrid.f
+++ b/src/3d/stepgrid.f
@@ -30,17 +30,15 @@ c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 c#### common/comxyzt/dtcom,dxcom,dycom,dzcom,tcom,icom,jcom,kcom
 
-      parameter (msize=max1d+4)
-
-      parameter (mwork=msize*(46*maxvar + (maxvar+1)*maxwave
-     &                 + 9*maxaux + 3))
+      integer msize, mwork
 
       dimension q(nvar,mitot,mjtot,mktot)
       dimension fm(nvar,mitot,mjtot,mktot),fp(nvar,mitot,mjtot,mktot)
       dimension gm(nvar,mitot,mjtot,mktot),gp(nvar,mitot,mjtot,mktot)
       dimension hm(nvar,mitot,mjtot,mktot),hp(nvar,mitot,mjtot,mktot)
       dimension aux(maux,mitot,mjtot,mktot)
-      dimension work(mwork)
+      dimension work((max1d+4)*(46*maxvar+(maxvar+1)*maxwave + 
+     &               9*maxaux + 3))
 
       logical    debug,  dump
       data       debug/.false./,  dump/.false./
@@ -50,6 +48,9 @@ c     # be included in the Riemann solver, for example, if t is explicitly
 c     # needed there.
 
       tcom = time
+c
+      msize = max1d + 4
+      mwork = msize*(46*maxvar + (maxvar+1)*maxwave+9*maxaux + 3)
 
 c
 !--        if (dump .and. mptr .ne. 1) 

--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -24,6 +24,9 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
         # Need to have a pointer to this so we can get num_dim and num_aux
         self._clawdata = clawdata
         
+        # maximum size of patch in each dimension:
+        self.add_attribute('max1d',60)
+
         # Refinement control
         self.add_attribute('amr_levels_max',1)
         self.add_attribute('refinement_ratios_x',[1])
@@ -64,6 +67,7 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
 
         self.open_data_file(out_file, data_source)
     
+        self.data_write('max1d')
         self.data_write('amr_levels_max')
 
         num_ratios = max(abs(self.amr_levels_max)-1, 1)

--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -25,7 +25,13 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
         self._clawdata = clawdata
         
         # maximum size of patch in each dimension:
-        self.add_attribute('max1d',60)
+        # match original defaults for consistency and nosetests
+        if self._clawdata.num_dim == 3:
+            self.add_attribute('max1d',32)
+        elif self._clawdata.num_dim == 2:
+            self.add_attribute('max1d',60)
+        else:
+            self.add_attribute('max1d',500)
 
         # Refinement control
         self.add_attribute('amr_levels_max',1)


### PR DESCRIPTION
max1d now a variable with default set in data.py.  Value is written to amr.data, fortran code reads it.

Previously was hardwired in amr_module. Useful for parallel runs without having to recompile everything. Can now be specified in setrun.py, by setting `amrdata.max1d = VALUE` 
Implemented in 1,2d, and 3d. Will need a PR in geoclaw too.