### PR TITLE
Switch `mstart` from being a local variable to the one stored in `amr_module`

### DIFF
--- a/src/1d/intfil.f90
+++ b/src/1d/intfil.f90
@@ -23,7 +23,7 @@ subroutine intfil(val,mi,time,flaguse,nrowst,ilo,ihi,level,nvar,naux,msrc)
     use amr_module, only: possk, mxnest, iregsz, nghost, outunit, alloc
     use amr_module, only: node, lstart, store1, store2, levelptr, timemult,gridNbor
     use amr_module, only: rnode, ndilo, ndihi, nextfree
-    use amr_module, only: bndListNum, bndListSt
+    use amr_module, only: bndListNum, bndListSt, mstart
     use amr_module, only: listStart, listOfGrids, bndList, numgrids
 
     implicit none
@@ -40,7 +40,7 @@ subroutine intfil(val,mi,time,flaguse,nrowst,ilo,ihi,level,nvar,naux,msrc)
     integer :: imlo, imhi, nx, mitot
     integer :: ixlo, ixhi, locold, locnew, nextSpot
     integer :: icount, bndNum, bndLoc, levSt
-    integer :: ivar, i, mptr, mstart, loc, numg
+    integer :: ivar, i, mptr, loc, numg
     real(kind=8) :: dt, alphac, alphai
     logical :: t_interpolate
 

--- a/src/2d/intfil.f90
+++ b/src/2d/intfil.f90
@@ -102,7 +102,7 @@ subroutine intfil(val,aux,mi,mj,time,flaguse,nrowst,ncolst,ilo,ihi,jlo,jhi,   &
   use amr_module, only: possk, mxnest, iregsz, jregsz, nghost, outunit, alloc
   use amr_module, only: node, lstart, store1, store2, storeaux, levelptr, timemult,gridNbor
   use amr_module, only: rnode, ndilo, ndihi, ndjlo, ndjhi, nextfree
-  use amr_module, only: bndListNum, bndListSt
+  use amr_module, only: bndListNum, bndListSt, mstart
   use amr_module, only: listStart, listOfGrids, bndList, numgrids
 
   implicit none
@@ -119,7 +119,7 @@ subroutine intfil(val,aux,mi,mj,time,flaguse,nrowst,ncolst,ilo,ihi,jlo,jhi,   &
   integer :: imlo, jmlo, imhi, jmhi, nx, ny, mitot, mjtot
   integer :: ixlo, ixhi, jxlo, jxhi, locold, locnew, nextSpot
   integer :: icount, bndNum, bndLoc, levSt, locaux, iaux, ialloc
-  integer :: ivar, i, j, mptr, mstart, loc, numg
+  integer :: ivar, i, j, mptr, loc, numg
   real(kind=8) :: dt, alphac, alphai
   logical :: t_interpolate,do_aux_copy
 


### PR DESCRIPTION
This appears to be an issue when the f90 refactor occurred.  This fixes that.