### PR TITLE
close fort.b and fort.a files properly in valout

### DIFF
--- a/src/1d/valout.f90
+++ b/src/1d/valout.f90
@@ -164,6 +164,12 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
         end do
     end do
 
+    close(out_unit)
+    if (output_format == 3) then
+        close(unit=out_unit + 1)
+    end if
+
+
     ! ==========================================================================
     ! Write out fort.a file
     if (out_aux) then
@@ -244,6 +250,11 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
                 grid_ptr = node(levelptr, grid_ptr)
             end do
         end do
+            
+        if ((output_format == 1) .or. (output_format == 3)) then
+            close(out_unit)
+        end if
+        
     end if
 
     ! ==========================================================================

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -205,7 +205,12 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
             grid_ptr = node(levelptr, grid_ptr)
         end do
     end do
+
     close(out_unit)
+    if (output_format == 3) then
+        close(unit=out_unit + 1)
+    end if
+
 #ifdef HDF5
     if (output_format == 4) then
         call h5gclose_f(q_group, hdf_error)
@@ -316,7 +321,13 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
                 grid_ptr = node(levelptr, grid_ptr)
             end do
         end do
+        
+        if ((output_format == 1) .or. (output_format == 3)) then
+            close(out_unit)
+        end if
+        
     end if
+
 #ifdef HDF5
     if (out_aux) then
         call h5gclose_f(aux_group, hdf_error)

--- a/src/3d/valout.f90
+++ b/src/3d/valout.f90
@@ -189,6 +189,12 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
         end do
     end do
 
+    close(out_unit)
+    if (output_format == 3) then
+        close(unit=out_unit + 1)
+    end if
+
+
     ! ==========================================================================
     ! Write out fort.a file
     if (out_aux) then
@@ -283,6 +289,11 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
                 grid_ptr = node(levelptr, grid_ptr)
             end do
         end do
+        
+        if ((output_format == 1) .or. (output_format == 3)) then
+            close(out_unit)
+        end if
+        
     end if
 
     ! ==========================================================================


### PR DESCRIPTION
Previously fort.b file wasn't properly closed until next frame written.
If trying to plot interactively as frames are computed, this caused Iplotclaw to
throw an error when trying to read an open file.

Note: in geoclaw this was already done properly, with a different unit `binary_unit` rather than using `out_unit + 1`, which is cleaner.