### PR TITLE
fix verbosity_regrid and improve format

### DIFF
--- a/src/2d/domain.f
+++ b/src/2d/domain.f
@@ -61,8 +61,11 @@ c  parallelization
        iregridcount(1) = 1
        if (ngrids .gt. 1) call arrangeGrids(1,ngrids)
 
-       write(*,100) ngrids,ncells
- 100   format("there are ",i4," grids with ",i8," cells at level   1")
+       write(*,100) 1,start_time,ngrids,ncells
+       write(outunit,100) 1,start_time,ngrids,ncells
+ 100          format("Gridding level ",i3," at t =",e14.6, ":",i6,
+     &               " grids with ",i11," cells")
+
 
 c      set lbase to 1 here, to put domain 1 grids in lsit
 c      once and for all.  Only here, this once, (and if restarting)

--- a/src/2d/regrid.f
+++ b/src/2d/regrid.f
@@ -30,7 +30,6 @@ c global
 c    mstart  = start of very coarsest grids.
 c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 c
-      !verbosity_regrid = method(4)
       lcheck    = min0(lfine,mxnest-1)
       lfnew     = lbase
       do 10 i   = 1, mxnest

--- a/src/2d/regrid.f
+++ b/src/2d/regrid.f
@@ -30,7 +30,7 @@ c global
 c    mstart  = start of very coarsest grids.
 c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 c
-      verbosity_regrid = method(4)
+      !verbosity_regrid = method(4)
       lcheck    = min0(lfine,mxnest-1)
       lfnew     = lbase
       do 10 i   = 1, mxnest
@@ -105,10 +105,10 @@ c        balancing, but doesn't help locality
          if (ngridcount .gt. 1) call arrangeGrids(levnew,ngridcount)
 
          if (verbosity_regrid .ge. levnew) then
-           write(*,100) ngridcount,ncells,levnew
-           write(outunit,100) ngridcount,ncells,levnew
- 100       format("there are ",i6," grids with ",i10,
-     &            " cells at level ", i3)
+           write(*,100) levnew,time,ngridcount,ncells
+           write(outunit,100) levnew,time,ngridcount,ncells
+ 100       format("Regridding level ",i3," at t =",e14.6, ":",i6,
+     &            " grids with ",i11," cells")
          endif
 72     continue
 c

--- a/src/2d/setgrd.f
+++ b/src/2d/setgrd.f
@@ -25,7 +25,6 @@ c
 c
       levnew =  2
       time   = start_time
-      !verbosity_regrid = method(4)  ! separate amr_module variable
 c
  10   if (levnew .gt. mxnest) go to 30
           levold = levnew - 1

--- a/src/2d/setgrd.f
+++ b/src/2d/setgrd.f
@@ -25,7 +25,7 @@ c
 c
       levnew =  2
       time   = start_time
-      verbosity_regrid = method(4)
+      !verbosity_regrid = method(4)  ! separate amr_module variable
 c
  10   if (levnew .gt. mxnest) go to 30
           levold = levnew - 1
@@ -88,9 +88,10 @@ c
           iregridcount(levnew) = iregridcount(levnew) + 1
           if (ngrids .gt. 1) call arrangeGrids(levnew,ngrids)
           if (verbosity_regrid .ge. levnew) then
-             write(*,100) ngrids,ncells,levnew
- 100         format("there are ",i6," grids with ",i10,
-     &               " cells at level ", i3)
+              write(*,100) levnew,start_time,ngrids,ncells
+              write(outunit,100) levnew,start_time,ngrids,ncells
+ 100          format("Gridding level ",i3," at t =",e14.6, ":",i6,
+     &               " grids with ",i11," cells")
           endif 
 c
 c     need to make gridList here before calling again to make finer grids.

--- a/src/2d/tick.f
+++ b/src/2d/tick.f
@@ -218,7 +218,8 @@ c
  81          tlevel(i) = tlevel(lbase)
 c
 c          MJB: modified to check level where new grids start, which is lbase+1
-          if (verbosity_regrid.ge.lbase+1) then
+          !if (verbosity_regrid.ge.lbase+1) then
+          if (.false.) then  ! don't need to print these every time:
                  do levnew = lbase+1,lfine
                      write(6,1006) intratx(levnew-1),intraty(levnew-1),
      &                             kratio(levnew-1),levnew


### PR DESCRIPTION
The parameter `verbosity_regrid` can be set in `setrun.py` to specify output desired about each regridding.  It is supposed to be independent of `verbosity`, but was being reset to `method(4)`, which is `verbosity` in the code.

In addition to fixing that, I improved the output it produces, so that it prints the time of regridding too. So now if `verbosity == 0` and it is not printing other info each time step it can still print more useful  regridding info.

If this looks ok I will make the same changes in geoclaw.

Sample output with  `verbosity == 0` and `verbosity_regrid == 3`:

```
 Storage allocated...
 bndList allocated...
Gridding level   1 at t =  0.000000E+00:     1 grids with        2500 cells
Gridding level   2 at t =  0.000000E+00:     4 grids with        4356 cells
Gridding level   3 at t =  0.000000E+00:    12 grids with        6400 cells
  max threads set to            4
  
 Done reading data, starting computation ...  
  
 Total mass at initial time:   0.32500000000001256     
AMRCLAW: Frame    0 output files done at time t =  0.000000D+00

Regridding level   3 at t =  0.160000E-01:    12 grids with        7200 cells
Regridding level   2 at t =  0.340000E-01:     4 grids with        7800 cells
Regridding level   3 at t =  0.340000E-01:    12 grids with        7200 cells
Regridding level   3 at t =  0.520000E-01:    12 grids with        7600 cells
Regridding level   2 at t =  0.700000E-01:     4 grids with        6240 cells
Regridding level   3 at t =  0.700000E-01:    12 grids with        7600 cells
Regridding level   3 at t =  0.880000E-01:    12 grids with        8000 cells
Regridding level   2 at t =  0.106000E+00:     4 grids with        6240 cells
Regridding level   3 at t =  0.106000E+00:    12 grids with        7600 cells
Regridding level   3 at t =  0.124000E+00:    12 grids with        7600 cells
Regridding level   2 at t =  0.142000E+00:     4 grids with        6240 cells
Regridding level   3 at t =  0.142000E+00:    12 grids with        8000 cells
Regridding level   3 at t =  0.160000E+00:    12 grids with        8000 cells
Regridding level   2 at t =  0.178000E+00:     4 grids with        6240 cells
Regridding level   3 at t =  0.178000E+00:    12 grids with        8000 cells
Regridding level   3 at t =  0.196000E+00:    12 grids with        8000 cells
AMRCLAW: Frame    1 output files done at time t =  0.200000D+00
```

