### PR TITLE
Allow memsize to be set in setrun.py

### DIFF
--- a/examples/advection_2d_square/setrun.py
+++ b/examples/advection_2d_square/setrun.py
@@ -113,8 +113,8 @@ def setrun(claw_pkg='amrclaw'):
     if clawdata.output_style==1:
         # Output ntimes frames at equally spaced times up to tfinal:
         # Can specify num_output_times = 0 for no output
-        clawdata.num_output_times = 10
-        clawdata.tfinal = 2.0
+        clawdata.num_output_times = 1
+        clawdata.tfinal = 0.2
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
     elif clawdata.output_style == 2:
@@ -268,6 +268,9 @@ def setrun(claw_pkg='amrclaw'):
     # AMR parameters:
     # ---------------
     amrdata = rundata.amrdata
+
+    # memsize is initial length of alloc array used for AMR patches
+    amrdata.memsize = 69200
 
     # max1d controls size of grids
     amrdata.max1d = 60

--- a/examples/advection_2d_square/setrun.py
+++ b/examples/advection_2d_square/setrun.py
@@ -113,8 +113,8 @@ def setrun(claw_pkg='amrclaw'):
     if clawdata.output_style==1:
         # Output ntimes frames at equally spaced times up to tfinal:
         # Can specify num_output_times = 0 for no output
-        clawdata.num_output_times = 1
-        clawdata.tfinal = 0.2
+        clawdata.num_output_times = 10
+        clawdata.tfinal = 2.0
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
     elif clawdata.output_style == 2:
@@ -270,7 +270,7 @@ def setrun(claw_pkg='amrclaw'):
     amrdata = rundata.amrdata
 
     # memsize is initial length of alloc array used for AMR patches
-    amrdata.memsize = 69200
+    amrdata.memsize = 100000
 
     # max1d controls size of grids
     amrdata.max1d = 60

--- a/src/1d/amr1.f90
+++ b/src/1d/amr1.f90
@@ -88,7 +88,7 @@ program amr1
     use amr_module, only: timeBound,timeStepgrid, timeFlagger,timeBufnst,timeFilvalTot
     use amr_module, only: timeBoundCPU,timeStepGridCPU,timeSetauxCPU,timeRegriddingCPU
     use amr_module, only: timeSetaux, timeSetauxCPU, timeValoutCPU
-    use amr_module, only: kcheck, iorder, lendim, lenmax
+    use amr_module, only: kcheck, iorder, lendim, lenmax, memsize
 
     use amr_module, only: dprint, eprint, edebug, gprint, nprint, pprint
     use amr_module, only: rprint, sprint, tprint, uprint
@@ -298,6 +298,7 @@ program amr1
     !  Refinement Control
     call opendatafile(inunit, amrfile)
 
+    read(inunit,*) memsize  ! initial size of alloc array
     read(inunit,*) max1d  ! max size of each grid patch
 
     read(inunit,*) mxnest
@@ -579,6 +580,8 @@ program amr1
     call tick(nvar,cut,nstart,vtime,time,naux,t0,rest,dt_max)
     ! --------------------------------------------------------
 
+    write(*,"('See fort.amr for more info on this run and memory usage')")
+
     call system_clock(clock_finish,clock_rate)
     call cpu_time(cpu_finish)
     
@@ -762,9 +765,10 @@ program amr1
 
     write(outunit,*)
     write(outunit,*)
-    write(outunit,"('current  space usage = ',i12)") lentotsave
-    write(outunit,"('maximum  space usage = ',i12)") lenmax
-    write(outunit,"('need space dimension = ',i12,/)") lendim
+    write(outunit,"('alloc array statistics:')")
+    write(outunit,"('    current alloc usage = ',i12)") lentotsave
+    write(outunit,"('    maximum alloc usage = ',i12)") lenmax
+    write(outunit,"('required alloc memsize >= ',i12,/)") lendim
 
     write(outunit,"('number of cells advanced for time integration = ',f20.6)")&
                     rvol

--- a/src/1d/init_alloc.f90
+++ b/src/1d/init_alloc.f90
@@ -9,16 +9,15 @@
 
 
 subroutine init_alloc()
+
+    ! new way, use allocatable arrays, not pointers
     
     use amr_module
     implicit none
     
-!    if (.not.allocated(storage)) then   ! old way, changed mjb sept. 2014
-    if (.not.allocated(alloc)) then      ! new way, use allocatable arrays, not pointers
-        memsize = 1000000
-!        allocate(storage(memsize)) 
+    if (.not.allocated(alloc)) then
+        !memsize = 1000000  # Now read in from amr.data by amr1.f90
         allocate(alloc(memsize))
-!        alloc => storage
         print *, "Storage allocated..."
     else
         print *, "Storage already allocated!"

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -632,7 +632,7 @@ program amr2
     call tick(nvar,cut,nstart,vtime,time,naux,t0,rest,dt_max)
     ! --------------------------------------------------------
 
-    write(*,*) 'Max usage of alloc array (can use for memsize): ',lendim
+    write(*,"('See fort.amr for more info on this run and memory usage')")
 
     ! call system_clock to get clock_finish and count_max for debug output:
     call system_clock(clock_finish,clock_rate,count_max)
@@ -803,9 +803,10 @@ program amr2
 
     write(outunit,*)
     write(outunit,*)
-    write(outunit,"('current  space usage = ',i12)") lentotsave
-    write(outunit,"('maximum  space usage = ',i12)") lenmax
-    write(outunit,"('need space dimension = ',i12,/)") lendim
+    write(outunit,"('alloc array statistics:')")
+    write(outunit,"('    current alloc usage = ',i12)") lentotsave
+    write(outunit,"('    maximum alloc usage = ',i12)") lenmax
+    write(outunit,"('required alloc memsize >= ',i12,/)") lendim
 
     write(outunit,"('number of cells advanced for time integration = ',f20.6)")&
                     rvol

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -64,7 +64,7 @@ program amr2
     use amr_module, only: checkpt_style, checkpt_interval, tchk, nchkpt
     use amr_module, only: rstfile, check_a
 
-    use amr_module, only: max1d, maxvar, maxlv
+    use amr_module, only: max1d, maxvar, maxlv, memsize
 
     use amr_module, only: method, mthlim, use_fwaves, numgrids
     use amr_module, only: nghost, mwaves, mcapa, auxtype, dimensional_split
@@ -342,6 +342,7 @@ program amr2
     !  Refinement Control
     call opendatafile(inunit, amrfile)
 
+    read(inunit,*) memsize  ! initial size of alloc array
     read(inunit,*) max1d  ! max size of each grid patch
 
     read(inunit,*) mxnest
@@ -630,6 +631,8 @@ program amr2
 
     call tick(nvar,cut,nstart,vtime,time,naux,t0,rest,dt_max)
     ! --------------------------------------------------------
+
+    write(*,*) 'Max usage of alloc array (can use for memsize): ',lendim
 
     ! call system_clock to get clock_finish and count_max for debug output:
     call system_clock(clock_finish,clock_rate,count_max)

--- a/src/2d/amr2.f90
+++ b/src/2d/amr2.f90
@@ -64,7 +64,7 @@ program amr2
     use amr_module, only: checkpt_style, checkpt_interval, tchk, nchkpt
     use amr_module, only: rstfile, check_a
 
-    use amr_module, only: max1d, maxvar, maxlv, memsize
+    use amr_module, only: max1d, maxvar, maxlv
 
     use amr_module, only: method, mthlim, use_fwaves, numgrids
     use amr_module, only: nghost, mwaves, mcapa, auxtype, dimensional_split
@@ -84,7 +84,7 @@ program amr2
     use amr_module, only: timeBound,timeStepgrid, timeFlagger,timeBufnst
     use amr_module, only: timeBoundCPU,timeStepGridCPU,timeRegriddingCPU
     use amr_module, only: timeValoutCPU,timeTick,timeTickCPU
-    use amr_module, only: kcheck, iorder, lendim, lenmax
+    use amr_module, only: kcheck, iorder, lendim, lenmax, memsize
 
     use amr_module, only: dprint, eprint, edebug, gprint, nprint, pprint
     use amr_module, only: rprint, sprint, tprint, uprint

--- a/src/2d/init_alloc.f90
+++ b/src/2d/init_alloc.f90
@@ -15,7 +15,7 @@ subroutine init_alloc()
     
 !    if (.not.allocated(storage)) then   ! old way, changed mjb sept. 2014
     if (.not.allocated(alloc)) then      ! new way, use allocatable arrays, not pointers
-        memsize = 4000000
+!       memsize = 4000000  # Now read in from amr.data by amr2.f90
 !        allocate(storage(memsize)) 
         allocate(alloc(memsize))
 !        alloc => storage

--- a/src/2d/init_alloc.f90
+++ b/src/2d/init_alloc.f90
@@ -9,16 +9,15 @@
 
 
 subroutine init_alloc()
+
+    ! new way, use allocatable arrays, not pointers
     
     use amr_module
     implicit none
     
-!    if (.not.allocated(storage)) then   ! old way, changed mjb sept. 2014
-    if (.not.allocated(alloc)) then      ! new way, use allocatable arrays, not pointers
-!       memsize = 4000000  # Now read in from amr.data by amr2.f90
-!        allocate(storage(memsize)) 
+    if (.not.allocated(alloc)) then
+        !memsize = 4000000  # Now read in from amr.data by amr2.f90
         allocate(alloc(memsize))
-!        alloc => storage
         print *, "Storage allocated..."
     else
         print *, "Storage already allocated!"

--- a/src/3d/amr3.f90
+++ b/src/3d/amr3.f90
@@ -86,7 +86,7 @@ program amr3
     use amr_module, only: timeBound,timeStepgrid
     use amr_module, only: timeBoundCPU,timeStepgridCPU
     use amr_module, only: timeValout,timeValoutCPU
-    use amr_module, only: kcheck, iorder, lendim, lenmax
+    use amr_module, only: kcheck, iorder, lendim, lenmax, memsize
 
     use amr_module, only: dprint, eprint, edebug, gprint, nprint, pprint
     use amr_module, only: rprint, sprint, tprint, uprint
@@ -330,6 +330,7 @@ program amr3
     !  Refinement Control
     call opendatafile(inunit, amrfile)
 
+    read(inunit,*) memsize  ! initial size of alloc array
     read(inunit,*) max1d  ! max size of each grid patch
 
     read(inunit,*) mxnest
@@ -623,6 +624,8 @@ program amr3
     call tick(nvar,cut,nstart,vtime,time,naux,t0,rest,dt_max)
     ! --------------------------------------------------------
 
+    write(*,"('See fort.amr for more info on this run and memory usage')")
+
     call system_clock(clock_finish,clock_rate)
     call cpu_time(cpu_finish)
     
@@ -782,9 +785,10 @@ program amr3
 
     write(outunit,*)
     write(outunit,*)
-    write(outunit,"('current  space usage = ',i12)") lentotsave
-    write(outunit,"('maximum  space usage = ',i12)") lenmax
-    write(outunit,"('need space dimension = ',i12,/)") lendim
+    write(outunit,"('alloc array statistics:')")
+    write(outunit,"('    current alloc usage = ',i12)") lentotsave
+    write(outunit,"('    maximum alloc usage = ',i12)") lenmax
+    write(outunit,"('required alloc memsize >= ',i12,/)") lendim
 
     write(outunit,"('number of cells advanced for time integration = ',f20.6)")&
                     rvol

--- a/src/3d/init_alloc.f90
+++ b/src/3d/init_alloc.f90
@@ -8,21 +8,20 @@
 ! ============================================================================
 
 
-      subroutine init_alloc()
-    
-      use amr_module
-      implicit none
+subroutine init_alloc()
 
-!      if (.not.allocated(storage)) then   ! old way, changed mjb jan. 2015
-       if (.not.allocated(alloc)) then     ! new way, use allocatable arrays, not pointers
-          memsize = 4000000
-!         allocate(storage(memsize))
-          allocate(alloc(memsize))
-!          alloc => storage
-          print *, "Storage allocated..."
-      else
-          print *, "Storage already allocated!"
-      endif
+    ! new way, use allocatable arrays, not pointers
+
+    use amr_module
+    implicit none
+
+    if (.not.allocated(alloc)) then
+        !memsize = 4000000  # Now read in from amr.data by amr3.f90
+        allocate(alloc(memsize))
+        print *, "Storage allocated..."
+    else
+        print *, "Storage already allocated!"
+    endif
     
-      end subroutine init_alloc
+end subroutine init_alloc
 

--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -29,6 +29,7 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
         if self._clawdata.num_dim == 3:
             self.add_attribute('max1d',32)
         elif self._clawdata.num_dim == 2:
+            self.add_attribute('memsize',4000000)
             self.add_attribute('max1d',60)
         else:
             self.add_attribute('max1d',500)
@@ -73,6 +74,9 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
 
         self.open_data_file(out_file, data_source)
     
+        if self._clawdata.num_dim == 2:
+            # eventually do this also in 1d and 3d
+            self.data_write('memsize')
         self.data_write('max1d')
         self.data_write('amr_levels_max')
 

--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -24,14 +24,19 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
         # Need to have a pointer to this so we can get num_dim and num_aux
         self._clawdata = clawdata
         
-        # maximum size of patch in each dimension:
-        # match original defaults for consistency and nosetests
+        # set max1d, maximum size of patch in each dimension
+        # and memsize, initial length of alloc array 
+        #    use default values so that repeated doubling gets as close as
+        #    possible to 2**30-1 = 2147483647, beyond which integer(kind=4)
+        #    indexes overflow and it would be necessary to use kind=8.
         if self._clawdata.num_dim == 3:
+            self.add_attribute('memsize',8388607)
             self.add_attribute('max1d',32)
         elif self._clawdata.num_dim == 2:
-            self.add_attribute('memsize',4000000)
+            self.add_attribute('memsize',4194303)
             self.add_attribute('max1d',60)
         else:
+            self.add_attribute('memsize',1048575)
             self.add_attribute('max1d',500)
 
         # Refinement control
@@ -74,9 +79,7 @@ class AmrclawInputData(clawpack.clawutil.data.ClawData):
 
         self.open_data_file(out_file, data_source)
     
-        if self._clawdata.num_dim == 2:
-            # eventually do this also in 1d and 3d
-            self.data_write('memsize')
+        self.data_write('memsize')
         self.data_write('max1d')
         self.data_write('amr_levels_max')
 


### PR DESCRIPTION
If not set, the default value agrees with what was previously used, but now memsize is written to `amr.data` and read in by `amr2.f90`. 

I only changed this in 2d so far, but if it looks ok I'll do the same in 1d and 3d, and also in GeoClaw, where it will be particularly useful.

It also prints out the `lendim` value at the end, indicating what `memsize` should be used in the future.

I temporarily modified `examples/advection_2d_square` to illustrate this. As currently set, `memsize = 69200` and it doubles the size once
```
 Expanding storage from        69200  to       138400
```
and then at the end prints out:
```
Max usage of alloc array (can use for memsize):        69211
```
Running again with this value of `memsize` it runs without expanding `alloc`.
