### PR TITLE
add support for binary gauge files containing float32 values

### DIFF
--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -435,8 +435,8 @@ class GaugeData(clawpack.clawutil.data.ClawData):
             self.expand_gauge_format_option(key)
 
         # File format
-        self._out_file.write("# File format (1=ascii, 2=binary)\n")
-        format_map = {'ascii':1, 'binary': 2}
+        self._out_file.write("# File format (1=ascii, 2=binary64, 3=binary32)\n")
+        format_map = {'ascii':1, 'binary':2, 'binary64':2, 'binary32':3}
         for gauge_num in self.gauge_numbers:
             try:
                 file_format = format_map[self.file_format[gauge_num].lower()]


### PR DESCRIPTION
Goes with https://github.com/clawpack/geoclaw/pull/537 to allow specifying `binary32` as the `file_format` for gauges, which stores 4-byte floats.