### PR TITLE
Fix valout.f90 in 2d and 3d to call bound before binary output.

### DIFF
--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -174,8 +174,12 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
             else if (output_format==2 .or. output_format==3) then
                 ! binary32 or binary64
                                 
-                ! Note: We are writing out ghost cell data also
-                ! do we need to call bound to update ghost cells??
+                ! Note: We are writing out ghost cell data also,
+                ! so need to update this
+                call bound(time,num_eqn,num_ghost,alloc(q_loc),     &
+                             num_cells(1) + 2*num_ghost,            &
+                             num_cells(2) + 2*num_ghost,            &
+                             grid_ptr,alloc(aux_loc),num_aux)
 
                 i = (iadd(num_eqn, num_cells(1) + 2 * num_ghost, &
                                    num_cells(2) + 2 * num_ghost))

--- a/src/3d/valout.f90
+++ b/src/3d/valout.f90
@@ -169,8 +169,14 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
             else if (output_format==2 .or. output_format==3) then
                 ! binary32 or binary64
                                 
-                ! Note: We are writing out ghost cell data also
-                ! do we need to call bound to update ghost cells??
+                ! Note: We are writing out ghost cell data also,
+                ! so need to update this
+                call bound(time,num_eqn,num_ghost,alloc(q_loc),     &
+                             num_cells(1) + 2*num_ghost,            &
+                             num_cells(2) + 2*num_ghost,            &
+                             num_cells(3) + 2*num_ghost,            &
+                             grid_ptr,alloc(aux_loc),num_aux)
+
 
                 i = (iadd(num_eqn, num_cells(1) + 2 * num_ghost, &
                                    num_cells(2) + 2 * num_ghost, &


### PR DESCRIPTION
Should not matter unless user wants to explicitly use patch ghost cell values, e.g. to compute vorticity.

Also prevents code from dying with junk in ghost cells when some compiler checks used.