### PR TITLE
Fix restart frame number when output_t0 is True

### DIFF
--- a/examples/acoustics_1d_adjoint/Makefile
+++ b/examples/acoustics_1d_adjoint/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/acoustics_1d_adjoint/setrun.py
+++ b/examples/acoustics_1d_adjoint/setrun.py
@@ -98,11 +98,11 @@ def setrun(claw_pkg='amrclaw'):
     # Note: If restarting, you must also change the Makefile to set:
     #    RESTART = True
     # If restarting, t0 above should be from original run, and the
-    # restart_file 'fort.qNNNN' specified below should be in 
+    # restart_file 'fort.chkNNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.
 
     clawdata.restart = False               # True to restart from prior results
-    clawdata.restart_file = 'fort.q0006'   # File to use for restart data
+    clawdata.restart_file = 'fort.chk00006'   # File to use for restart data
     
     
     # -------------

--- a/examples/acoustics_1d_heterogeneous/Makefile
+++ b/examples/acoustics_1d_heterogeneous/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/acoustics_1d_heterogeneous/setrun.py
+++ b/examples/acoustics_1d_heterogeneous/setrun.py
@@ -92,11 +92,11 @@ def setrun(claw_pkg='amrclaw'):
     # Note: If restarting, you must also change the Makefile to set:
     #    RESTART = True
     # If restarting, t0 above should be from original run, and the
-    # restart_file 'fort.qNNNN' specified below should be in 
+    # restart_file 'fort.chkNNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.
 
     clawdata.restart = False               # True to restart from prior results
-    clawdata.restart_file = 'fort.q0006'   # File to use for restart data
+    clawdata.restart_file = 'fort.chk00006'   # File to use for restart data
     
     
     # -------------

--- a/examples/acoustics_1d_homogeneous/Makefile
+++ b/examples/acoustics_1d_homogeneous/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/acoustics_1d_homogeneous/setrun.py
+++ b/examples/acoustics_1d_homogeneous/setrun.py
@@ -88,11 +88,11 @@ def setrun(claw_pkg='amrclaw'):
     # Note: If restarting, you must also change the Makefile to set:
     #    RESTART = True
     # If restarting, t0 above should be from original run, and the
-    # restart_file 'fort.qNNNN' specified below should be in 
+    # restart_file 'fort.chkNNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.
 
     clawdata.restart = False               # True to restart from prior results
-    clawdata.restart_file = 'fort.q0006'   # File to use for restart data
+    clawdata.restart_file = 'fort.chk00006'   # File to use for restart data
     
     
     # -------------

--- a/examples/advection_1d_example1/Makefile
+++ b/examples/advection_1d_example1/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/advection_1d_example1/setrun.py
+++ b/examples/advection_1d_example1/setrun.py
@@ -87,11 +87,11 @@ def setrun(claw_pkg='amrclaw'):
     # Note: If restarting, you must also change the Makefile to set:
     #    RESTART = True
     # If restarting, t0 above should be from original run, and the
-    # restart_file 'fort.qNNNN' specified below should be in 
+    # restart_file 'fort.chkNNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.
 
     clawdata.restart = False               # True to restart from prior results
-    clawdata.restart_file = 'fort.q0006'   # File to use for restart data
+    clawdata.restart_file = 'fort.chk00006'   # File to use for restart data
     
     
     # -------------

--- a/examples/euler_1d_wcblast/setrun.py
+++ b/examples/euler_1d_wcblast/setrun.py
@@ -85,11 +85,11 @@ def setrun(claw_pkg='amrclaw'):
     # Note: If restarting, you must also change the Makefile to set:
     #    RESTART = True
     # If restarting, t0 above should be from original run, and the
-    # restart_file 'fort.qNNNN' specified below should be in 
+    # restart_file 'fort.chkNNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.
 
     clawdata.restart = False               # True to restart from prior results
-    clawdata.restart_file = 'fort.q0006'   # File to use for restart data
+    clawdata.restart_file = 'fort.chk00006'   # File to use for restart data
     
     
     # -------------

--- a/src/1d/restrt.f
+++ b/src/1d/restrt.f
@@ -11,6 +11,7 @@ c
  
       logical foundFile
       dimension intrtx(maxlv),intrtt(maxlv)
+      integer matlabu0
 c
 c :::::::::::::::::::::::::::: RESTRT ::::::::::::::::::::::::::::::::
 c read back in the check point files written by subr. check.
@@ -39,6 +40,8 @@ c     rstfile  = 'restart.data'
       open(rstunit,file=trim(rstfile),status='old',form='unformatted')
       rewind rstunit
 
+      matlabu0 = matlabu ! value set by amr2, 0 if output_t0, else 1
+
       read(rstunit) lenmax,lendim,isize
 
 c     # need to allocate for dynamic memory:
@@ -57,6 +60,8 @@ c     # need to allocate for dynamic memory:
      1              evol,rvol,rvoll,lentot,tmass0,cflmax
 
       close(rstunit) 
+
+      matlabu = matlabu - 1 + matlabu0 ! redo previous frame if output_t0
 
       write(outunit,100) nsteps,time
       write(6,100) nsteps,time

--- a/src/2d/restrt.f
+++ b/src/2d/restrt.f
@@ -11,6 +11,7 @@ c
  
       logical foundFile
       dimension intrtx(maxlv),intrty(maxlv),intrtt(maxlv)
+      integer matlabu0
 c
 c :::::::::::::::::::::::::::: RESTRT ::::::::::::::::::::::::::::::::
 !> read back in the check point files written by subr. check.
@@ -39,6 +40,8 @@ c     rstfile  = 'restart.data'
       open(rstunit,file=trim(rstfile),status='old',form='unformatted')
       rewind rstunit
 
+      matlabu0 = matlabu ! value set by amr2, 0 if output_t0, else 1
+
       !!read(rstunit) lenmax,lendim,isize
       !! new version has flexible node size, so need to read current size maxgr
       read(rstunit) lenmax,lendim,isize,maxgr
@@ -65,6 +68,8 @@ c     # need to allocate for dynamic memory:
      6              timeValout,timeValoutCPU 
 
       close(rstunit) 
+
+      matlabu = matlabu - 1 + matlabu0 ! redo previous frame if output_t0
 
       write(outunit,100) nsteps,time
       write(6,100) nsteps,time

--- a/src/3d/restrt.f
+++ b/src/3d/restrt.f
@@ -10,6 +10,8 @@ c
  
       logical foundFile
       dimension intrtx(maxlv),intrty(maxlv),intrtz(maxlv),intrtt(maxlv)
+      integer matlabu0
+
 c
 c :::::::::::::::::::::::::::: RESTRT ::::::::::::::::::::::::::::::::
 c read back in the check point files written by subr. check.
@@ -39,6 +41,9 @@ c     rstfile  = 'restart.data'
       open(rstunit,file=trim(rstfile),status='old',form='unformatted')
       rewind rstunit
 
+      matlabu0 = matlabu ! value set in amr3, 0 if output_t0, else 1
+
+      !!read(rstunit) lenmax,lendim,isize
       !! new version has flexible node size, so need to read current size maxgr
       read(rstunit) lenmax,lendim,isize,maxgr
 
@@ -59,6 +64,8 @@ c     # need to allocate for dynamic memory:
      1              evol,rvol,rvoll,lentot,tmass0,cflmax
 
       close(rstunit) 
+
+      matlabu = matlabu - 1 + matlabu0 ! redo previous frame if output_t0
 
       write(outunit,100) nsteps,time
       write(6,100) nsteps,time


### PR DESCRIPTION
    Fix src/Nd/restrt.f so that frame number is not advanced if output_t0 is True
    
    In this case it re-writes the last frame from the original calculation
    when restarting, and it should reuse that frame number.  For historical
    reasons the frame number is called matlabu, stored in amr_module.f90