### PR TITLE
Add meson.build.

### DIFF
--- a/src/python/amrclaw/meson.build
+++ b/src/python/amrclaw/meson.build
@@ -1,0 +1,16 @@
+package = 'clawpack.amrclaw'
+pkg_dir = join_paths(package.split('.'))
+
+python_sources = [
+  '__init__.py',
+  'compare_gauges.py',
+  'data.py',
+  'region_tools.py',
+  'test.py',
+]
+
+py.install_sources(
+  python_sources,
+  subdir: pkg_dir,
+)
+


### PR DESCRIPTION
Only installs python files for now.

This is the first phase of switching to meson (away from distutils). This allows meson to install python files only. The second phase is to add compilation of the Fortran extensions (for Python).

For now, this will have no effect since the meson build is not enabled at the top level.