### PR TITLE
Gauge filenames

### DIFF
--- a/src/1d/gauges_module.f90
+++ b/src/1d/gauges_module.f90
@@ -67,7 +67,8 @@ contains
         ! Locals
         integer :: i, ipos, idigit
         integer, parameter :: iunit = 7
-        character*14 ::  fileName
+        character(len=24) :: fileName
+        character(len=15) :: numstr
 
         if (.not. module_setup) then
 
@@ -101,13 +102,13 @@ contains
             nextLoc  = 1  ! next location to be filled with gauge info
 
             do i = 1, num_gauges
-               fileName = 'gaugexxxxx.txt'    ! NB different name convention too
+
                inum = igauge(i)
-               do ipos = 10,6,-1              ! do this to replace the xxxxx in the name
-                  idigit = mod(inum,10)
-                  fileName(ipos:ipos) = char(ichar('0') + idigit)
-                  inum = inum / 10
-               end do
+
+               ! convert inum to string numstr with zero padding if <5 digits
+               ! since we want format gauge00012.txt or gauge1234567.txt:
+               write (numstr,'(I0.5)') inum
+               fileName = 'gauge'//trim(numstr)//'.txt'
 
     !          status unknown since might be a restart run. might need to rewind
                if (restart) then
@@ -118,7 +119,7 @@ contains
                        position='append', form='formatted')
                   rewind OUTGAUGEUNIT
                   write(OUTGAUGEUNIT,100) igauge(i), xgauge(i), nvar
-  100             format("# gauge_id= ",i5," location=( ",1e15.7," ) num_eqn= ",i2)
+  100             format("# gauge_id= ",i0," location=( ",1e15.7," ) num_eqn= ",i2)
                   write(OUTGAUGEUNIT,101)
   101             format("# Columns: level time q(1 ... num_eqn)")
                endif
@@ -348,7 +349,8 @@ contains
       implicit none
       integer :: gaugeNum,nvar,j,inum,k,idigit,ipos,myunit
       integer :: omp_get_thread_num, mythread
-      character*14 :: fileName
+      character(len=24) :: fileName
+      character(len=15) :: numstr
 
       ! open file for gauge gaugeNum, figure out name
       ! not writing gauge number since it is in file name now
@@ -358,13 +360,11 @@ contains
       ! NB: output written in different order, losing backward compatibility
 
 
-      fileName = 'gaugexxxxx.txt'    ! NB different name convention too
       inum = igauge(gaugeNum)
-      do ipos = 10,6,-1              ! do this to replace the xxxxx in the name
-         idigit = mod(inum,10)
-         fileName(ipos:ipos) = char(ichar('0') + idigit)
-         inum = inum / 10
-      end do
+      ! convert inum to string numstr with zero padding if <5 digits
+      ! since we want format gauge00012.txt or gauge1234567.txt:
+      write (numstr,'(I0.5)') inum
+      fileName = 'gauge'//trim(numstr)//'.txt'
 
 
       mythread = 0

--- a/src/2d/gauges_module.f90
+++ b/src/2d/gauges_module.f90
@@ -57,7 +57,7 @@ module gauges_module
         ! Gauge number
         integer :: gauge_num
 
-        character(len=14) :: file_name
+        character(len=24) :: file_name
 
         ! Location in time and space
         real(kind=8) :: x, y, t_start, t_end
@@ -106,6 +106,7 @@ contains
         integer, parameter :: UNIT = 7
         character(len=128) :: header_1
         character(len=40) :: q_column, aux_column
+        character(len=15) :: numstr
 
         if (.not. module_setup) then
 
@@ -194,13 +195,12 @@ contains
 
             ! Create gauge output files
             do i = 1, num_gauges
-                gauges(i)%file_name = 'gaugexxxxx.txt'
                 num = gauges(i)%gauge_num
-                do pos = 10, 6, -1
-                    digit = mod(num,10)
-                    gauges(i)%file_name(pos:pos) = char(ichar('0') + digit)
-                    num = num / 10
-                end do
+
+                ! convert num to string numstr with zero padding if <5 digits
+                ! since we want format gauge00012.txt or gauge1234567.txt:
+                write (numstr,'(I0.5)') num
+                gauges(i)%file_name = 'gauge'//trim(numstr)//'.txt'
 
                 ! Handle restart
                 if (restart) then
@@ -212,7 +212,7 @@ contains
                     rewind OUTGAUGEUNIT
 
                     ! Write header
-                    header_1 = "('# gauge_id= ',i5,' " //                   &
+                    header_1 = "('# gauge_id= ',i0,' " //                   &
                                "location=( ',1e17.10,' ',1e17.10,' ) " //     &
                                "num_var= ',i2)"
                     write(OUTGAUGEUNIT, header_1) gauges(i)%gauge_num,      &

--- a/src/3d/gauges_module.f90
+++ b/src/3d/gauges_module.f90
@@ -47,7 +47,7 @@ module gauges_module
         ! Gauge number
         integer :: gauge_num
 
-        character(len=14) :: file_name
+        character(len=24) :: file_name
 
         ! Location in time and space
         real(kind=8) :: x, y, z, t_start, t_end
@@ -98,6 +98,7 @@ contains
         integer, parameter :: UNIT = 7
         character(len=128) :: header_1
         character(len=40) :: q_column, aux_column
+        character(len=15) :: numstr
 
         if (.not. module_setup) then
 
@@ -188,13 +189,12 @@ contains
 
             ! Create gauge output files
             do i = 1, num_gauges
-                gauges(i)%file_name = 'gaugexxxxx.txt'
                 num = gauges(i)%gauge_num
-                do pos = 10, 6, -1
-                    digit = mod(num,10)
-                    gauges(i)%file_name(pos:pos) = char(ichar('0') + digit)
-                    num = num / 10
-                end do
+
+                ! convert num to string numstr with zero padding if <5 digits
+                ! since we want format gauge00012.txt or gauge1234567.txt:
+                write (numstr,'(I0.5)') num
+                gauges(i)%file_name = 'gauge'//trim(numstr)//'.txt'
 
                 ! Handle restart
                 if (restart) then
@@ -206,7 +206,7 @@ contains
                     rewind OUTGAUGEUNIT
 
                     ! Write header
-                    header_1 = "('# gauge_id= ',i5,' " //                   &
+                    header_1 = "('# gauge_id= ',i0,' " //                   &
                                "location=( ',1e17.10,' ',1e17.10,' ',1e17.10,' ) " //     &
                                "num_var= ',i2)"
                     write(OUTGAUGEUNIT, header_1) gauges(i)%gauge_num,      &

--- a/src/python/amrclaw/data.py
+++ b/src/python/amrclaw/data.py
@@ -418,6 +418,12 @@ class GaugeData(clawpack.clawutil.data.ClawData):
             if len(self.gauge_numbers) != len(set(self.gauge_numbers)):
                 raise Exception("Non unique gauge numbers specified.")
 
+        for gaugeno in self.gauge_numbers:
+            if abs(gaugeno) >= 2**31:
+                raise Exception("Gauge number %i is too large, must be < 2**31"\
+                    % gaugeno)
+
+
         # Write out gauge data file
         self.open_data_file(out_file,data_source)
         self.data_write(name='ngauges',value=len(self.gauges))


### PR DESCRIPTION
Same changes as in https://github.com/clawpack/geoclaw/pull/615, and now allows gauge number up to 9 digits (actually up to `2**31 - 1 = 2147483647` since it is stored as an 4-byte integer).