### PR TITLE
fix euler_3d_radial/qinit.f90 to agree with v4.x version

### DIFF
--- a/examples/euler_3d_radial/qinit.f90
+++ b/examples/euler_3d_radial/qinit.f90
@@ -25,7 +25,7 @@ subroutine qinit(meqn, mbc, mx, my, mz, xlower, ylower, zlower, dx, dy, dz, q, m
                 q(2, i, j, k) = 0.d0
                 q(3, i, j, k) = 0.d0
                 q(4, i, j, k) = 0.d0
-                q(5, i, j, k) = 0.d0
+                q(5, i, j, k) = rho
             end do
         end do
     end do


### PR DESCRIPTION
This example was failing due to energy/pressure being 0. Now it should run at least.

At some point we should improve this example to add a `1d_radial` version to compute a reference solution and then plot a scatter plot of the 3d solution for comparison.