### PR TITLE
modify so gauge always written at starting time

### DIFF
--- a/src/2d/gauges_module.f90
+++ b/src/2d/gauges_module.f90
@@ -145,17 +145,17 @@ contains
             read(UNIT, *)
             read(UNIT, *) (gauges(i)%gtype, i=1, num_gauges)
 
-            do i=1,num_gauges
-               ! initialize last_time so that first gauge output will be
-               ! at time gauges(i)%t_start regardless of min_time_increment:
-               gauges(i)%last_time = gauges(i)%t_start - 1.d0 &
-                                      - gauges(i)%min_time_increment
-            enddo
 
             ! Read in q fields
             read(UNIT, *)
             read(UNIT, *)
             do i = 1, num_gauges
+
+               ! initialize last_time so that first gauge output will be
+               ! at time gauges(i)%t_start regardless of min_time_increment:
+               gauges(i)%last_time = gauges(i)%t_start - 1.d0 &
+                                      - gauges(i)%min_time_increment
+
                 if (gauges(i)%gtype .ne. 1) then
                     write(6,*) '*** Lagrangian gauges not yet supported'
                     write(6,*) '*** All gauges must have gtype==1'

--- a/src/2d/gauges_module.f90
+++ b/src/2d/gauges_module.f90
@@ -129,7 +129,6 @@ contains
                 read(UNIT, *) gauges(i)%gauge_num, gauges(i)%x, gauges(i)%y, &
                               gauges(i)%t_start, gauges(i)%t_end
                 gauges(i)%buffer_index = 1
-                gauges(i)%last_time = gauges(i)%t_start
             enddo
 
             ! Read in output formats
@@ -145,6 +144,13 @@ contains
             read(UNIT, *)
             read(UNIT, *)
             read(UNIT, *) (gauges(i)%gtype, i=1, num_gauges)
+
+            do i=1,num_gauges
+               ! initialize last_time so that first gauge output will be
+               ! at time gauges(i)%t_start regardless of min_time_increment:
+               gauges(i)%last_time = gauges(i)%t_start - 1.d0 &
+                                      - gauges(i)%min_time_increment
+            enddo
 
             ! Read in q fields
             read(UNIT, *)

--- a/src/3d/gauges_module.f90
+++ b/src/3d/gauges_module.f90
@@ -123,7 +123,6 @@ contains
                 read(UNIT, *) gauges(i)%gauge_num, gauges(i)%x, gauges(i)%y, &
                               gauges(i)%z, gauges(i)%t_start, gauges(i)%t_end
                 gauges(i)%buffer_index = 1
-                gauges(i)%last_time = gauges(i)%t_start
             enddo
 
             ! Read in output formats
@@ -144,6 +143,12 @@ contains
             read(UNIT, *)
             read(UNIT, *)
             do i = 1, num_gauges
+
+               ! initialize last_time so that first gauge output will be
+               ! at time gauges(i)%t_start regardless of min_time_increment:
+                gauges(i)%last_time = gauges(i)%t_start - 1.d0 &
+                                      - gauges(i)%min_time_increment
+
                 if (gauges(i)%gtype .ne. 1) then
                     write(6,*) '*** Lagrangian gauges not yet supported'
                     write(6,*) '*** All gauges must have gtype==1'


### PR DESCRIPTION
Previously if `min_time_increment > 0` was set for a gauge it wouldn't capture the gauge value until this long after the starting time value `t1` specified for the gauge.

Analogous to change in https://github.com/clawpack/geoclaw/pull/636.