### PR TITLE
fix timing_line definition in valout.f90

### DIFF
--- a/src/1d/valout.f90
+++ b/src/1d/valout.f90
@@ -311,9 +311,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     open(unit=out_unit, file=timing_file_name, form='formatted',         &
          status='old', action='write', position='append')
     
-    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6,"
+    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6"
     do level=1, mxnest
-        timing_substr = "', ', e16.6, ', ', e16.6, ', ', e16.6"
+        timing_substr = ", ', ', e16.6, ', ', e16.6, ', ', e16.6"
         timing_line = trim(timing_line) // timing_substr
     end do
     timing_line = trim(timing_line) // ")"

--- a/src/2d/valout.f90
+++ b/src/2d/valout.f90
@@ -396,9 +396,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
              status='unknown', action='write', position='append')
              !status='old', action='write', position='append')
     
-    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6,"
+    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6"
     do level=1, mxnest
-        timing_substr = "', ', e16.6, ', ', e16.6, ', ', e16.6"
+        timing_substr = ", ', ', e16.6, ', ', e16.6, ', ', e16.6"
         timing_line = trim(timing_line) // timing_substr
     end do
     timing_line = trim(timing_line) // ")"

--- a/src/3d/valout.f90
+++ b/src/3d/valout.f90
@@ -360,9 +360,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     open(unit=out_unit, file=timing_file_name, form='formatted',           &
              status='old', action='write', position='append')
     
-    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6,"
+    timing_line = "(e16.6, ', ', e16.6, ', ', e16.6"
     do level=1, mxnest
-        timing_substr = "', ', e16.6, ', ', e16.6, ', ', e16.6"
+        timing_substr = ", ', ', e16.6, ', ', e16.6, ', ', e16.6"
         timing_line = trim(timing_line) // timing_substr
     end do
     timing_line = trim(timing_line) // ")"


### PR DESCRIPTION
Add a missing comma that didn't seem to cause a problem with earlier gfortran but throws an error with 15.1.0.

Corresponding fix for GeoClaw: https://github.com/clawpack/geoclaw/pull/651