### PR TITLE
Fix Bug in `qinit` in `advection_2d_inflow` Example

### DIFF
--- a/examples/advection_2d_inflow/qinit.f90
+++ b/examples/advection_2d_inflow/qinit.f90
@@ -5,13 +5,23 @@ subroutine qinit(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
     ! q = 1.0  if  0.1 < x < 0.6   and   0.1 < y < 0.6
     !     0.1  otherwise
 
+    implicit none
+
     integer, intent(in) :: meqn, mbc, mx, my, maux
     real(kind=8), intent(in) :: xlower, ylower, dx, dy
     real(kind=8), intent(in out) :: q(meqn, 1-mbc:mx+mbc, 1-mbc:my+mbc)
     real(kind=8), intent(in out) :: aux(maux, 1-mbc:mx+mbc, 1-mbc:my+mbc)
 
+    integer :: i, j
     real(kind=8) :: xi, yj
-    real(kind=8), external :: qtrue
+    
+    ! True solution for BCs
+    interface
+        real(kind=8) pure function qtrue(x, y ,t)
+            implicit none
+            real(kind=8), intent(in) :: x, y ,t
+        end function qtrue
+    end interface
 
     ! set concentration profile
     do j=1,my

--- a/examples/advection_2d_inflow/qinit.f90
+++ b/examples/advection_2d_inflow/qinit.f90
@@ -10,6 +10,7 @@ subroutine qinit(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
     real(kind=8), intent(in out) :: q(meqn, 1-mbc:mx+mbc, 1-mbc:my+mbc)
     real(kind=8), intent(in out) :: aux(maux, 1-mbc:mx+mbc, 1-mbc:my+mbc)
 
+    real(kind=8) :: xi, yj
     real(kind=8), external :: qtrue
 
     ! set concentration profile


### PR DESCRIPTION
As there was not `implicit none` in `qinit` the variables `xi` and `yj` were defaulting to single precision and somehow getting misinterpreted when relying on an external call to `qtrue`.  This currently add explicit declarations of `xi` and `yj` to fix this.  Declaring the interface to `qtrue` also gives an error due to type mismatch.  Full fix includes an `implicit none` and explicit typing for all variables and the function `qtrue`.